### PR TITLE
Fix go-ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
     - name: Check out code into GOPATH
       uses: actions/checkout@v1
       with:
-        path: go/src/github.com/${{ github.repository }}
+        path: go/src/github.com/GoogleContainerTools/kpt-functions-sdk
     - name: Build, Test, Lint
       run: |
         cd go


### PR DESCRIPTION
Fix the go-ci workflow because its Build, Test, Lint step fails in forks of this project.

This is because the workflow checks out code into go/src/github.com/${{ github.repository }} while our go code imports from go/src/github.com/GoogleContainerTools/kpt-functions-sdk/...

Hardcode this path in the workflow so it will still pass in forks.