### PR TITLE
Modify instructions to specify Kubernetes 1.15

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -47,7 +47,7 @@ The easiest way to get developing is to use `kind` to bring up a cluster running
    apiVersion: kind.sigs.k8s.io/v1alpha3
    kubeadmConfigPatches:
    - |
-     apiVersion: kubeadm.k8s.io/v1beta1 # Use v1beta1 for 1.14, v1beta2 for 1.15+
+     apiVersion: kubeadm.k8s.io/v1beta2
      kind: ClusterConfiguration
      metadata:
        name: config
@@ -64,7 +64,7 @@ The easiest way to get developing is to use `kind` to bring up a cluster running
 1. Create the cluster:
 
    ```sh
-   kind create cluster --name=kpt-functions --config=kind.yaml --image=kindest/node:v1.14.6
+   kind create cluster --name=kpt-functions --config=kind.yaml --image=kindest/node:v1.15.9
    ```
 
 #### Using a GKE cluster
@@ -73,8 +73,8 @@ You can also use a deployed cluster in GKE. The beta k8s feature is avilable onl
 `--enable-kubernetes-alpha` flag, as seen here:
 
 ```sh
-gcloud container clusters create $USER-1-14-alpha --enable-kubernetes-alpha --cluster-version=latest --no-enable-autoupgrade --region=us-central1-a --project <PROJECT>
-gcloud container clusters get-credentials $USER-1-14-alpha --zone us-central1-a --project <PROJECT>
+gcloud container clusters create $USER-1-15 --cluster-version=latest --region=us-central1-a --project <PROJECT>
+gcloud container clusters get-credentials $USER-1-15 --zone us-central1-a --project <PROJECT>
 ```
 
 ### Working with CRDs

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -64,7 +64,7 @@ The easiest way to get developing is to use `kind` to bring up a cluster running
 1. Create the cluster:
 
    ```sh
-   kind create cluster --name=kpt-functions --config=kind.yaml --image=kindest/node:v1.15.9
+   kind create cluster --name=kpt-functions --config=kind.yaml --image=kindest/node:v1.15.7
    ```
 
 #### Using a GKE cluster

--- a/scripts/init-package.sh
+++ b/scripts/init-package.sh
@@ -26,7 +26,7 @@ then
   echo "kind delete cluster --name=generate-init-pkg"
 else
     # Use images from https://hub.docker.com/r/kindest/node/tags
-    kind create cluster --name=generate-init-pkg --config=scripts/kind-config.yaml --image=kindest/node:v1.15.9
+    kind create cluster --name=generate-init-pkg --config=scripts/kind-config.yaml --image=kindest/node:v1.15.7
     sleep 10 # Wait for cluster to become fully available. Potentially flaky.
 fi
 

--- a/scripts/init-package.sh
+++ b/scripts/init-package.sh
@@ -26,7 +26,7 @@ then
   echo "kind delete cluster --name=generate-init-pkg"
 else
     # Use images from https://hub.docker.com/r/kindest/node/tags
-    kind create cluster --name=generate-init-pkg --config=scripts/kind-config.yaml --image=kindest/node:v1.14.6@sha256:464a43f5cf6ad442f100b0ca881a3acae37af069d5f96849c1d06ced2870888d
+    kind create cluster --name=generate-init-pkg --config=scripts/kind-config.yaml --image=kindest/node:v1.15.9
     sleep 10 # Wait for cluster to become fully available. Potentially flaky.
 fi
 

--- a/scripts/kind-config.yaml
+++ b/scripts/kind-config.yaml
@@ -16,7 +16,7 @@ kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta1 # Use v1beta1 for 1.14, v1beta2 for 1.15+
+  apiVersion: kubeadm.k8s.io/v1beta2
   kind: ClusterConfiguration
   metadata:
     name: config


### PR DESCRIPTION
Instructions no longer work on GCP for 1.14. These require alpha
features to be enabled, but there is a conflict with alpha features that
causes the API Server to generate an incomplete swagger.json.

Surfacing CRDs in the OpenAPI Spec is beta in 1.15 and automatically
activated, so using 1.15 works.

DOES NOT WORK IN GCP WITH ALPHA FEATURES ENABLED, FOR ANY VERSION.