### PR TITLE
Ignore Mac .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 .npmrc
 go/.out
 ts/create-kpt-functions/bin
+.DS_Store
+


### PR DESCRIPTION
Mac OS automatically creates .DS_Store files in all directories so configure .gitignore to ignore such files.