### PR TITLE
Enable functions to return structured results.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ node_modules
 go/.out
 ts/create-kpt-functions/bin
 .DS_Store
+*.swo
+*.swp
 

--- a/ts/demo-functions/src/validate_rolebinding.ts
+++ b/ts/demo-functions/src/validate_rolebinding.ts
@@ -34,7 +34,10 @@ export async function validateRolebinding(configs: Configs) {
     .filter(
       rb => rb && rb.subjects && rb.subjects.find(s => s.name === subjectName)
     )
-    .map(rb => new KubernetesObjectError('Object has banned subject', rb));
+    .map(
+      rb =>
+        new KubernetesObjectError(`Found banned subject '${subjectName}'`, rb)
+    );
 
   if (errors.length) {
     throw new MultiConfigError(

--- a/ts/kpt-functions/src/errors.ts
+++ b/ts/kpt-functions/src/errors.ts
@@ -55,7 +55,7 @@ export class ConfigError extends Error {
   }
 
   /**
-   * String representation that will be logged to stderr. 
+   * String representation that will be logged to stderr.
    */
   toString(): string {
     return `${this.name}: ${this.message} (${this.severity})`;
@@ -129,15 +129,17 @@ export class KubernetesObjectError extends ConfigError {
     readonly object: KubernetesObject,
     readonly field?: FieldInfo,
     readonly severity: Severity = 'error',
-    readonly tags?: { [key: string]: string },
+    readonly tags?: { [key: string]: string }
   ) {
     super(message, severity, tags);
     this.name = 'KubernetesObjectError';
   }
 
   toIssues(): Issue[] {
-    const path: string | undefined =
-     getAnnotation(this.object, SOURCE_PATH_ANNOTATION);
+    const path: string | undefined = getAnnotation(
+      this.object,
+      SOURCE_PATH_ANNOTATION
+    );
     const index: number | undefined =
       Number(getAnnotation(this.object, SOURCE_INDEX_ANNOTATION)) || undefined;
     return [
@@ -155,7 +157,7 @@ export class KubernetesObjectError extends ConfigError {
           path: path,
           index: index,
         },
-        field: this.field
+        field: this.field,
       },
     ];
   }
@@ -163,10 +165,10 @@ export class KubernetesObjectError extends ConfigError {
   toString(): string {
     const issue = this.toIssues()[0];
     const r = issue.resourceRef!;
-    let s = `${this.name}: ${this.message} for resource ${r.apiVersion}/${r.kind}/${r.namespace}/${r.name}`
+    let s = `${this.name}: ${this.message} in object ${r.apiVersion}/${r.kind}/${r.namespace}/${r.name}`;
     const path = issue.file && issue.file.path;
     if (path) {
-      s += ` in file p`;
+      s += ` in file ${path}`;
     }
     s += ` (${this.severity})`;
     return s;
@@ -186,6 +188,9 @@ export class MultiConfigError extends ConfigError {
     this.name = 'MultiConfigError';
   }
 
+  /**
+   * Add the given ConfigError to the collection.
+   */
   push(error: ConfigError) {
     this.errors.push(error);
   }

--- a/ts/kpt-functions/src/errors.ts
+++ b/ts/kpt-functions/src/errors.ts
@@ -16,9 +16,9 @@
 
 import { KubernetesObject, Issue, Severity } from './types';
 import {
+  SOURCE_INDEX_ANNOTATION,
   SOURCE_PATH_ANNOTATION,
   getAnnotation,
-  SOURCE_INDEX_ANNOTATION,
 } from './metadata';
 
 /**
@@ -42,7 +42,7 @@ export class ConfigError extends Error {
   }
 
   /**
-   * Structured representation of the issue that will be included as part of function stdout.
+   * Structured representation of the issue.
    */
   toIssues(): Issue[] {
     return [
@@ -55,10 +55,17 @@ export class ConfigError extends Error {
   }
 
   /**
-   * String representation that will be logged to stderr.
+   * String representation of the issue.
    */
   toString(): string {
     return `${this.name}: ${this.message} (${this.severity})`;
+  }
+
+  /**
+   * Logs issue to stderr.
+   */
+  log() {
+    console.error(this.toString());
   }
 }
 
@@ -96,7 +103,7 @@ export class ConfigFileError extends ConfigError {
   }
 
   toString(): string {
-    return `${this.name}: ${this.message} in file ${this.path} (${this.severity})`;
+    return `${this.name}: ${this.message} in file '${this.path}' (${this.severity})`;
   }
 }
 
@@ -165,10 +172,10 @@ export class KubernetesObjectError extends ConfigError {
   toString(): string {
     const issue = this.toIssues()[0];
     const r = issue.resourceRef!;
-    let s = `${this.name}: ${this.message} in object ${r.apiVersion}/${r.kind}/${r.namespace}/${r.name}`;
+    let s = `${this.name}: ${this.message} in object '${r.apiVersion}/${r.kind}/${r.namespace}/${r.name}'`;
     const path = issue.file && issue.file.path;
     if (path) {
-      s += ` in file ${path}`;
+      s += ` in file '${path}'`;
     }
     s += ` (${this.severity})`;
     return s;
@@ -210,5 +217,14 @@ export class MultiConfigError extends ConfigError {
       .sort()
       .join('\n');
     return `${this.name}: ${this.message}\n\n${e}`;
+  }
+}
+
+/**
+ * Represents an error with the functionConfig used to parametrize the function.
+ */
+export class FunctionConfigError extends Error {
+  constructor(message: string) {
+    super(message);
   }
 }

--- a/ts/kpt-functions/src/errors_test.ts
+++ b/ts/kpt-functions/src/errors_test.ts
@@ -23,8 +23,8 @@ import {
 import { KubernetesObject } from './types';
 import {
   addAnnotation,
-  SOURCE_PATH_ANNOTATION,
   SOURCE_INDEX_ANNOTATION,
+  SOURCE_PATH_ANNOTATION,
 } from './metadata';
 
 describe('Errors', () => {
@@ -208,8 +208,8 @@ describe('Errors', () => {
       expect(e.toString()).toEqual(`MultiConfigError: foo
 
 [1] ConfigError: hello (warning)
-[2] ConfigFileError: world in file a/b/c.yaml (error)
-[3] KubernetesObjectError: bye in object v1/Namespace/bar/foo (error)`);
+[2] ConfigFileError: world in file 'a/b/c.yaml' (error)
+[3] KubernetesObjectError: bye in object 'v1/Namespace/bar/foo' (error)`);
     });
   });
 });

--- a/ts/kpt-functions/src/errors_test.ts
+++ b/ts/kpt-functions/src/errors_test.ts
@@ -86,9 +86,15 @@ describe('Errors', () => {
     });
 
     it('path/index/field undefined', () => {
-      const e = new KubernetesObjectError('hello', someObject, undefined, 'note', {
-        color: 'blue',
-      });
+      const e = new KubernetesObjectError(
+        'hello',
+        someObject,
+        undefined,
+        'note',
+        {
+          color: 'blue',
+        }
+      );
 
       expect(e.toIssues()).toEqual([
         {
@@ -130,11 +136,11 @@ describe('Errors', () => {
     });
 
     it('field defined', () => {
-      const e = new KubernetesObjectError(
-        'hello',
-        someObject,
-        { path: 'x.y.z[0]', currentValue: 1, suggestedValue: 2 }
-      );
+      const e = new KubernetesObjectError('hello', someObject, {
+        path: 'x.y.z[0]',
+        currentValue: 1,
+        suggestedValue: 2,
+      });
 
       expect(e.toIssues()).toEqual([
         {
@@ -159,17 +165,14 @@ describe('Errors', () => {
     e.push(new ConfigError('hello', 'warning'));
     e.push(new ConfigFileError('world', 'a/b/c.yaml', 'error'));
     e.push(
-      new KubernetesObjectError(
-        'bye',
-        {
-          apiVersion: 'v1',
-          kind: 'Namespace',
-          metadata: {
-            name: 'foo',
-            namespace: 'bar',
-          },
-        }
-      )
+      new KubernetesObjectError('bye', {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: {
+          name: 'foo',
+          namespace: 'bar',
+        },
+      })
     );
 
     it('toIssues', () => {
@@ -206,7 +209,7 @@ describe('Errors', () => {
 
 [1] ConfigError: hello (warning)
 [2] ConfigFileError: world in file a/b/c.yaml (error)
-[3] KubernetesObjectError: bye for resource v1/Namespace/bar/foo (error)`);
+[3] KubernetesObjectError: bye in object v1/Namespace/bar/foo (error)`);
     });
   });
 });

--- a/ts/kpt-functions/src/errors_test.ts
+++ b/ts/kpt-functions/src/errors_test.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ConfigError,
+  ConfigFileError,
+  KubernetesObjectError,
+  MultiConfigError,
+} from './errors';
+import { KubernetesObject } from './types';
+import {
+  addAnnotation,
+  SOURCE_PATH_ANNOTATION,
+  SOURCE_INDEX_ANNOTATION,
+} from './metadata';
+
+describe('Errors', () => {
+  describe('ConfigError', () => {
+    it('only message param', () => {
+      const e = new ConfigError('hello');
+
+      expect(e.toIssues()).toEqual([
+        {
+          message: 'hello',
+          severity: 'error',
+          tags: undefined,
+        },
+      ]);
+    });
+
+    it('all params', () => {
+      const e = new ConfigError('hello', 'warning', { color: 'blue' });
+
+      expect(e.toIssues()).toEqual([
+        {
+          message: 'hello',
+          severity: 'warning',
+          tags: { color: 'blue' },
+        },
+      ]);
+    });
+  });
+
+  describe('ConfigFileError', () => {
+    it('all params', () => {
+      const e = new ConfigFileError('hello', 'a/b/c.yaml', 'note', {
+        color: 'blue',
+      });
+
+      expect(e.toIssues()).toEqual([
+        {
+          message: 'hello',
+          severity: 'note',
+          tags: { color: 'blue' },
+          file: { path: 'a/b/c.yaml' },
+        },
+      ]);
+    });
+  });
+
+  describe('KubernetesObjectError', () => {
+    let someObject: KubernetesObject;
+
+    beforeEach(() => {
+      someObject = {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: {
+          name: 'foo',
+          namespace: 'bar',
+        },
+      };
+    });
+
+    it('path/index/field undefined', () => {
+      const e = new KubernetesObjectError('hello', someObject, undefined, 'note', {
+        color: 'blue',
+      });
+
+      expect(e.toIssues()).toEqual([
+        {
+          message: 'hello',
+          severity: 'note',
+          tags: { color: 'blue' },
+          resourceRef: {
+            apiVersion: 'v1',
+            kind: 'Namespace',
+            name: 'foo',
+            namespace: 'bar',
+          },
+          file: { path: undefined, index: undefined },
+          field: undefined,
+        },
+      ]);
+    });
+
+    it('path/index defined', () => {
+      addAnnotation(someObject, SOURCE_PATH_ANNOTATION, 'a/b/c.yaml');
+      addAnnotation(someObject, SOURCE_INDEX_ANNOTATION, '2');
+      const e = new KubernetesObjectError('hello', someObject);
+
+      expect(e.toIssues()).toEqual([
+        {
+          message: 'hello',
+          severity: 'error',
+          tags: undefined,
+          resourceRef: {
+            apiVersion: 'v1',
+            kind: 'Namespace',
+            name: 'foo',
+            namespace: 'bar',
+          },
+          file: { path: 'a/b/c.yaml', index: 2 },
+          field: undefined,
+        },
+      ]);
+    });
+
+    it('field defined', () => {
+      const e = new KubernetesObjectError(
+        'hello',
+        someObject,
+        { path: 'x.y.z[0]', currentValue: 1, suggestedValue: 2 }
+      );
+
+      expect(e.toIssues()).toEqual([
+        {
+          message: 'hello',
+          severity: 'error',
+          tags: undefined,
+          resourceRef: {
+            apiVersion: 'v1',
+            kind: 'Namespace',
+            name: 'foo',
+            namespace: 'bar',
+          },
+          file: { path: undefined, index: undefined },
+          field: { path: 'x.y.z[0]', currentValue: 1, suggestedValue: 2 },
+        },
+      ]);
+    });
+  });
+
+  describe('MultiConfigerror', () => {
+    const e = new MultiConfigError('foo');
+    e.push(new ConfigError('hello', 'warning'));
+    e.push(new ConfigFileError('world', 'a/b/c.yaml', 'error'));
+    e.push(
+      new KubernetesObjectError(
+        'bye',
+        {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: {
+            name: 'foo',
+            namespace: 'bar',
+          },
+        }
+      )
+    );
+
+    it('toIssues', () => {
+      expect(e.toIssues()).toEqual([
+        {
+          message: 'hello',
+          severity: 'warning',
+          tags: undefined,
+        },
+        {
+          message: 'world',
+          severity: 'error',
+          tags: undefined,
+          file: { path: 'a/b/c.yaml' },
+        },
+        {
+          message: 'bye',
+          severity: 'error',
+          tags: undefined,
+          resourceRef: {
+            apiVersion: 'v1',
+            kind: 'Namespace',
+            name: 'foo',
+            namespace: 'bar',
+          },
+          file: { path: undefined, index: undefined },
+          field: undefined,
+        },
+      ]);
+    });
+
+    it('toString', () => {
+      expect(e.toString()).toEqual(`MultiConfigError: foo
+
+[1] ConfigError: hello (warning)
+[2] ConfigFileError: world in file a/b/c.yaml (error)
+[3] KubernetesObjectError: bye for resource v1/Namespace/bar/foo (error)`);
+    });
+  });
+});

--- a/ts/kpt-functions/src/errors_test.ts
+++ b/ts/kpt-functions/src/errors_test.ts
@@ -32,7 +32,7 @@ describe('Errors', () => {
     it('only message param', () => {
       const e = new ConfigError('hello');
 
-      expect(e.toIssues()).toEqual([
+      expect(e.toResults()).toEqual([
         {
           message: 'hello',
           severity: 'error',
@@ -42,12 +42,12 @@ describe('Errors', () => {
     });
 
     it('all params', () => {
-      const e = new ConfigError('hello', 'warning', { color: 'blue' });
+      const e = new ConfigError('hello', 'warn', { color: 'blue' });
 
-      expect(e.toIssues()).toEqual([
+      expect(e.toResults()).toEqual([
         {
           message: 'hello',
-          severity: 'warning',
+          severity: 'warn',
           tags: { color: 'blue' },
         },
       ]);
@@ -56,14 +56,14 @@ describe('Errors', () => {
 
   describe('ConfigFileError', () => {
     it('all params', () => {
-      const e = new ConfigFileError('hello', 'a/b/c.yaml', 'note', {
+      const e = new ConfigFileError('hello', 'a/b/c.yaml', 'info', {
         color: 'blue',
       });
 
-      expect(e.toIssues()).toEqual([
+      expect(e.toResults()).toEqual([
         {
           message: 'hello',
-          severity: 'note',
+          severity: 'info',
           tags: { color: 'blue' },
           file: { path: 'a/b/c.yaml' },
         },
@@ -90,16 +90,16 @@ describe('Errors', () => {
         'hello',
         someObject,
         undefined,
-        'note',
+        'info',
         {
           color: 'blue',
         }
       );
 
-      expect(e.toIssues()).toEqual([
+      expect(e.toResults()).toEqual([
         {
           message: 'hello',
-          severity: 'note',
+          severity: 'info',
           tags: { color: 'blue' },
           resourceRef: {
             apiVersion: 'v1',
@@ -118,7 +118,7 @@ describe('Errors', () => {
       addAnnotation(someObject, SOURCE_INDEX_ANNOTATION, '2');
       const e = new KubernetesObjectError('hello', someObject);
 
-      expect(e.toIssues()).toEqual([
+      expect(e.toResults()).toEqual([
         {
           message: 'hello',
           severity: 'error',
@@ -142,7 +142,7 @@ describe('Errors', () => {
         suggestedValue: 2,
       });
 
-      expect(e.toIssues()).toEqual([
+      expect(e.toResults()).toEqual([
         {
           message: 'hello',
           severity: 'error',
@@ -161,9 +161,9 @@ describe('Errors', () => {
   });
 
   describe('MultiConfigerror', () => {
-    const e = new MultiConfigError('foo');
-    e.push(new ConfigError('hello', 'warning'));
-    e.push(new ConfigFileError('world', 'a/b/c.yaml', 'error'));
+    const e = new MultiConfigError();
+    e.push(new ConfigError('hello', 'warn'));
+    e.push(new ConfigFileError('world', 'a/b/c.yaml', 'info'));
     e.push(
       new KubernetesObjectError('bye', {
         apiVersion: 'v1',
@@ -175,16 +175,16 @@ describe('Errors', () => {
       })
     );
 
-    it('toIssues', () => {
-      expect(e.toIssues()).toEqual([
+    it('toResults', () => {
+      expect(e.toResults()).toEqual([
         {
           message: 'hello',
-          severity: 'warning',
+          severity: 'warn',
           tags: undefined,
         },
         {
           message: 'world',
-          severity: 'error',
+          severity: 'info',
           tags: undefined,
           file: { path: 'a/b/c.yaml' },
         },
@@ -205,11 +205,11 @@ describe('Errors', () => {
     });
 
     it('toString', () => {
-      expect(e.toString()).toEqual(`MultiConfigError: foo
+      expect(e.toString()).toEqual(`Found 3 issues:
 
-[1] ConfigError: hello (warning)
-[2] ConfigFileError: world in file 'a/b/c.yaml' (error)
-[3] KubernetesObjectError: bye in object 'v1/Namespace/bar/foo' (error)`);
+[1] [WARN] hello
+[2] [INFO] world in file 'a/b/c.yaml'
+[3] [ERROR] bye in object 'v1/Namespace/bar/foo'`);
     });
   });
 });

--- a/ts/kpt-functions/src/io.ts
+++ b/ts/kpt-functions/src/io.ts
@@ -16,7 +16,7 @@
 
 import { DumpOptions, safeDump, safeLoad } from 'js-yaml';
 import rw from 'rw';
-import { Configs, KubernetesObject } from './types';
+import { Configs, KubernetesObject, ResourceList } from './types';
 
 export enum FileFormat {
   YAML,
@@ -129,11 +129,7 @@ export async function writeConfigs(
  * @param format defines whether to write the configs as YAML or JSON.
  */
 export function stringify(configs: Configs, format: FileFormat): string {
-  const output = {
-    apiVersion: 'v1',
-    kind: 'List',
-    items: configs.getAll(),
-  };
+  const output = new ResourceList(configs.getAll());
 
   switch (format) {
     case FileFormat.JSON:

--- a/ts/kpt-functions/src/io.ts
+++ b/ts/kpt-functions/src/io.ts
@@ -16,7 +16,7 @@
 
 import { DumpOptions, safeDump, safeLoad } from 'js-yaml';
 import rw from 'rw';
-import { Configs, KubernetesObject, ResourceList, Issue } from './types';
+import { Configs, KubernetesObject, ResourceList, Result } from './types';
 
 export enum FileFormat {
   YAML,
@@ -109,19 +109,19 @@ function load(raw: string, format: FileFormat): any {
  * @param output Path to to the file to be created, it must not exist.
  * @param configs Contains objects to write to the output file.
  * @param format Defines whether to write the Configs as YAML or JSON.
- * @param issues List of config issues returned by the function.
+ * @param results List of config results returned by the function.
  */
 export async function writeConfigs(
   output: FilePath,
   configs: Configs,
   format: FileFormat,
-  issues?: Issue[]
+  results?: Result[]
 ): Promise<void> {
   if (output === '/dev/null') {
     return;
   }
 
-  await writeFile(output, stringify(configs, format, issues));
+  await writeFile(output, stringify(configs, format, results));
 }
 
 /**
@@ -129,14 +129,14 @@ export async function writeConfigs(
  *
  * @param configs The configs to convert to a string.
  * @param format defines whether to write the configs as YAML or JSON.
- * @param issues List of config issues returned by the function.
+ * @param results List of config results returned by the function.
  */
 export function stringify(
   configs: Configs,
   format: FileFormat,
-  issues?: Issue[]
+  results?: Result[]
 ): string {
-  const output = new ResourceList(configs.getAll(), issues);
+  const output = new ResourceList(configs.getAll(), results);
 
   switch (format) {
     case FileFormat.JSON:

--- a/ts/kpt-functions/src/io.ts
+++ b/ts/kpt-functions/src/io.ts
@@ -16,7 +16,7 @@
 
 import { DumpOptions, safeDump, safeLoad } from 'js-yaml';
 import rw from 'rw';
-import { Configs, KubernetesObject, ResourceList } from './types';
+import { Configs, KubernetesObject, ResourceList, Issue } from './types';
 
 export enum FileFormat {
   YAML,
@@ -108,18 +108,20 @@ function load(raw: string, format: FileFormat): any {
  *
  * @param output Path to to the file to be created, it must not exist.
  * @param configs Contains objects to write to the output file.
- * @param format defines whether to write the Configs as YAML or JSON.
+ * @param format Defines whether to write the Configs as YAML or JSON.
+ * @param issues List of config issues returned by the function.
  */
 export async function writeConfigs(
   output: FilePath,
   configs: Configs,
-  format: FileFormat
+  format: FileFormat,
+  issues?: Issue[]
 ): Promise<void> {
   if (output === '/dev/null') {
     return;
   }
 
-  await writeFile(output, stringify(configs, format));
+  await writeFile(output, stringify(configs, format, issues));
 }
 
 /**
@@ -127,9 +129,14 @@ export async function writeConfigs(
  *
  * @param configs The configs to convert to a string.
  * @param format defines whether to write the configs as YAML or JSON.
+ * @param issues List of config issues returned by the function.
  */
-export function stringify(configs: Configs, format: FileFormat): string {
-  const output = new ResourceList(configs.getAll());
+export function stringify(
+  configs: Configs,
+  format: FileFormat,
+  issues?: Issue[]
+): string {
+  const output = new ResourceList(configs.getAll(), issues);
 
   switch (format) {
     case FileFormat.JSON:

--- a/ts/kpt-functions/src/io_test.ts
+++ b/ts/kpt-functions/src/io_test.ts
@@ -25,11 +25,35 @@ describe('read', () => {
       expect(result.getAll()).toEqual([]);
     });
 
-    it('parses single object', () => {
+    it('parses List object', () => {
       const result = parse(
         `
 apiVersion: v1
 kind: List
+items:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: foo
+`,
+        FileFormat.YAML
+      );
+      expect(result.getAll()).toEqual([
+        {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: {
+            name: 'foo',
+          },
+        },
+      ]);
+    });
+
+    it('parses ResourceList object', () => {
+      const result = parse(
+        `
+apiVersion: v1
+kind: ResourceList
 items:
 - apiVersion: v1
   kind: Namespace
@@ -354,7 +378,9 @@ describe('write', () => {
       const result = stringify(new Configs(), FileFormat.YAML);
 
       expect(result).toEqual(`apiVersion: v1
-kind: List
+kind: ResourceList
+metadata:
+  name: output
 items: []
 `);
     });
@@ -375,7 +401,9 @@ items: []
 
       expect(result).toEqual(
         `apiVersion: v1
-kind: List
+kind: ResourceList
+metadata:
+  name: output
 items:
 - apiVersion: v1
   kind: Namespace
@@ -407,7 +435,9 @@ items:
       );
 
       expect(result).toEqual(`apiVersion: v1
-kind: List
+kind: ResourceList
+metadata:
+  name: output
 items:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -427,7 +457,10 @@ items:
 
       expect(result).toEqual(`{
   "apiVersion": "v1",
-  "kind": "List",
+  "kind": "ResourceList",
+  "metadata": {
+    "name": "output"
+  },
   "items": []
 }
 `);
@@ -449,7 +482,10 @@ items:
 
       expect(result).toEqual(`{
   "apiVersion": "v1",
-  "kind": "List",
+  "kind": "ResourceList",
+  "metadata": {
+    "name": "output"
+  },
   "items": [
     {
       "apiVersion": "v1",
@@ -486,7 +522,10 @@ items:
 
       expect(result).toEqual(`{
   "apiVersion": "v1",
-  "kind": "List",
+  "kind": "ResourceList",
+  "metadata": {
+    "name": "output"
+  },
   "items": [
     {
       "apiVersion": "rbac.authorization.k8s.io/v1",

--- a/ts/kpt-functions/src/io_test.ts
+++ b/ts/kpt-functions/src/io_test.ts
@@ -545,5 +545,21 @@ items:
 }
 `);
     });
+
+    it('has issues', () => {
+      const result = stringify(new Configs(), FileFormat.YAML, [
+        { message: 'hello', severity: 'error' },
+      ]);
+
+      expect(result).toEqual(`apiVersion: v1
+kind: ResourceList
+metadata:
+  name: output
+items: []
+issues:
+- message: hello
+  severity: error
+`);
+    });
   });
 });

--- a/ts/kpt-functions/src/io_test.ts
+++ b/ts/kpt-functions/src/io_test.ts
@@ -546,7 +546,7 @@ items:
 `);
     });
 
-    it('has issues', () => {
+    it('has results', () => {
       const result = stringify(new Configs(), FileFormat.YAML, [
         { message: 'hello', severity: 'error' },
       ]);
@@ -556,7 +556,7 @@ kind: ResourceList
 metadata:
   name: output
 items: []
-issues:
+results:
 - message: hello
   severity: error
 `);

--- a/ts/kpt-functions/src/run.ts
+++ b/ts/kpt-functions/src/run.ts
@@ -118,7 +118,7 @@ Use this ONLY if the function accepts a ConfigMap.`,
   parser.addArgument('--log-to-stderr', {
     action: 'storeTrue',
     help:
-      'Confguration issues should be logged to stderr in addition to the ".issues" field in the output',
+      'Confguration issues should be logged to stderr in addition to the ".results" field in the output',
   });
 
   // Parse args.
@@ -140,7 +140,8 @@ Use this ONLY if the function accepts a ConfigMap.`,
     }
     functionConfig = parseToConfigMap(parser, functionConfigLiterals);
   }
-  const logToStderr = Boolean(args.get('log_to_stderr'));
+  const logToStderr =
+    process.env.LOG_TO_STDERR || Boolean(args.get('log_to_stderr'));
 
   // Read the input and construct Configs.
   const configs = await readConfigs(inputFile, fileFormat, functionConfig);
@@ -154,7 +155,7 @@ Use this ONLY if the function accepts a ConfigMap.`,
         err.log();
       }
       // Include Issues as part of function's output.
-      await writeConfigs(outputFile, configs, fileFormat, err.toIssues());
+      await writeConfigs(outputFile, configs, fileFormat, err.toResults());
     }
     throw err;
   }

--- a/ts/kpt-functions/src/run.ts
+++ b/ts/kpt-functions/src/run.ts
@@ -17,7 +17,7 @@
 import { ArgumentParser, RawTextHelpFormatter } from 'argparse';
 import { FileFormat, readConfigs, writeConfigs } from './io';
 import { KptFunc, KubernetesObject } from './types';
-import { ConfigError } from './errors';
+import { ConfigError, FunctionConfigError } from './errors';
 
 const INVOCATIONS = `
 Example invocations:
@@ -58,6 +58,7 @@ Example invocations:
 enum ExitCode {
   CONFIG_ERROR = 1,
   EXCEPTION_ERROR,
+  FUNCTION_CONFIG_ERROR,
 }
 
 /**
@@ -71,8 +72,10 @@ export async function run(fn: KptFunc) {
     await runFn(fn);
   } catch (err) {
     if (err instanceof ConfigError) {
-      console.error(err.toString());
       process.exitCode = ExitCode.CONFIG_ERROR;
+    } else if (err instanceof FunctionConfigError) {
+      console.error(err.toString());
+      process.exitCode = ExitCode.FUNCTION_CONFIG_ERROR;
     } else {
       console.error(err.stack);
       process.exitCode = ExitCode.EXCEPTION_ERROR;
@@ -112,6 +115,11 @@ Use this ONLY if the function accepts a ConfigMap.`,
     action: 'storeTrue',
     help: 'Input and output files are in JSON instead of YAML',
   });
+  parser.addArgument('--log-to-stderr', {
+    action: 'storeTrue',
+    help:
+      'Confguration issues should be logged to stderr in addition to the ".issues" field in the output',
+  });
 
   // Parse args.
   const args = new Map(Object.entries(parser.parseArgs()));
@@ -132,12 +140,24 @@ Use this ONLY if the function accepts a ConfigMap.`,
     }
     functionConfig = parseToConfigMap(parser, functionConfigLiterals);
   }
+  const logToStderr = Boolean(args.get('log_to_stderr'));
 
   // Read the input and construct Configs.
   const configs = await readConfigs(inputFile, fileFormat, functionConfig);
 
   // Run the function.
-  await fn(configs);
+  try {
+    await fn(configs);
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      if (logToStderr) {
+        err.log();
+      }
+      // Include Issues as part of function's output.
+      await writeConfigs(outputFile, configs, fileFormat, err.toIssues());
+    }
+    throw err;
+  }
 
   // Write the output.
   await writeConfigs(outputFile, configs, fileFormat);

--- a/ts/kpt-functions/src/types.ts
+++ b/ts/kpt-functions/src/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { ObjectMeta } from './gen/io.k8s.apimachinery.pkg.apis.meta.v1';
-import { ConfigError } from './errors';
+import { FunctionConfigError } from './errors';
 
 /**
  * Interface describing KPT functions.
@@ -167,7 +167,7 @@ export class Configs {
   /**
    * Returns the value for the given key if functionConfig is of kind ConfigMap.
    *
-   * Throws a ConfigError if functionConfig kind is not a ConfigMap.
+   * Throws a FunctionConfigError if functionConfig kind is not a ConfigMap.
    *
    * Returns undefined if functionConfig is undefined OR
    * if the ConfigMap has no such key in the 'data' section.
@@ -180,7 +180,7 @@ export class Configs {
       return undefined;
     }
     if (!isConfigMap(cm)) {
-      throw new ConfigError(
+      throw new FunctionConfigError(
         `functionConfig expected to be of kind ConfigMap, instead got: ${cm.kind}`
       );
     }
@@ -193,7 +193,7 @@ export class Configs {
   getFunctionConfigValueOrThrow(key: string): string {
     const val = this.getFunctionConfigValue(key);
     if (val === undefined) {
-      throw new ConfigError(
+      throw new FunctionConfigError(
         `Missing 'data.${key}' in ConfigMap provided as functionConfig`
       );
     }

--- a/ts/kpt-functions/src/types.ts
+++ b/ts/kpt-functions/src/types.ts
@@ -328,7 +328,7 @@ export interface Issue {
   file?: {
     // OS agnostic, relative, slash-delimited path.
     // e.g. "some-dir/some-file.yaml"
-    path: string;
+    path?: string;
     // Index of the object in a multi-object YAML file.
     index?: number;
   }

--- a/ts/kpt-functions/src/types.ts
+++ b/ts/kpt-functions/src/types.ts
@@ -304,7 +304,7 @@ export type Severity = 'error' | 'warning' | 'note';
 
 /**
  * Issue represents a configuration-related issue returned by a function.
- * 
+ *
  * It can be at the following granularities:
  * - A file containing multiple objects
  * - A specific kubernetes object
@@ -323,7 +323,7 @@ export interface Issue {
     kind: string;
     namespace: string;
     name: string;
-  }
+  };
   // File-level for the issue.
   file?: {
     // OS agnostic, relative, slash-delimited path.
@@ -331,7 +331,7 @@ export interface Issue {
     path?: string;
     // Index of the object in a multi-object YAML file.
     index?: number;
-  }
+  };
   // A specific field in the object.
   field?: {
     // JSON Path
@@ -341,8 +341,7 @@ export interface Issue {
     currentValue: string | number | boolean;
     // Proposed value to fix the issue.
     suggestedValue: string | number | boolean;
-
-  }
+  };
 }
 
 interface ConfigMap extends KubernetesObject {

--- a/ts/kpt-functions/src/types.ts
+++ b/ts/kpt-functions/src/types.ts
@@ -285,32 +285,32 @@ export class ResourceList implements KubernetesObject {
     name: 'output',
   };
   readonly items: KubernetesObject[];
-  readonly issues?: Issue[];
+  readonly results?: Result[];
 
   /**
    * @param items List of Kubernetes objects returned by the function.
-   * @param issues List of issues returned by the function.
+   * @param results List of results returned by the function.
    */
-  constructor(items: KubernetesObject[], issues?: Issue[]) {
+  constructor(items: KubernetesObject[], results?: Result[]) {
     this.items = items;
-    this.issues = issues;
+    this.results = results;
   }
 }
 
 /**
- * Severity of a configuration issue.
+ * Severity of a configuration result.
  */
-export type Severity = 'error' | 'warning' | 'note';
+export type Severity = 'error' | 'warn' | 'info';
 
 /**
- * Issue represents a configuration-related issue returned by a function.
+ * Result represents a configuration-related issue returned by a function.
  *
  * It can be at the following granularities:
  * - A file containing multiple objects
  * - A specific kubernetes object
  * - A specific field of a kubernetes object
  */
-export interface Issue {
+export interface Result {
   // Severify of the issue.
   severity: Severity;
   // Message describing the issue.


### PR DESCRIPTION
- Add `.issues` to `ResourceList`
- Add `toIssues()` methods to ConfigError and its subclasses
- Add `--log-to-stderr` that optionally logs config issues to stderr. This is a change in behavior.