### PR TITLE
Type gen from sources

### DIFF
--- a/ts/create-kpt-functions/src/cmd/type_create.ts
+++ b/ts/create-kpt-functions/src/cmd/type_create.ts
@@ -26,40 +26,20 @@ import { log } from '../utils/log';
 import * as validator from '../utils/validator';
 import { spawnSync } from 'child_process';
 import { CLI_PACKAGE } from '../paths';
-import { warn } from '../utils/format';
+import { failure } from '../utils/format';
+
+// url for default swagger.json openAPI type definitions from kyaml library
+// current kubernetes version v1.17.1
+const BUILTIN_OPENAPI_URL = `https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/kyaml/openapi/kubernetesapi/swagger.json`;
 
 export async function typeCreate(packageDir: string) {
   const desc = 'Generating types from OpenAPI spec.';
   log(format.startMarker(desc));
-  // url for default swagger.json openAPI type definitions
-  let url = `https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/kyaml/openapi/kubernetesapi/swagger.json`;
-  // Get the kubeconfig context the user wants to use.
-  const kc = new KubeConfig();
-  kc.loadFromDefault();
-  const contexts = kc.contexts;
-  if (contexts.length != 0) {
-    const currentContext = kc.currentContext;
-    const contextIdx = chooseContext(contexts, currentContext);
-    const useContext = contexts[contextIdx];
-    const cluster = kc.clusters.find(c => c.name === useContext.cluster);
-    if (!cluster) {
-      throw new Error('Cluster for specified context not found.');
-    }
-    kc.setCurrentContext(useContext.name);
-    // set the url to cluster openAPI if cluster exists
-    url = `${cluster.server}/openapi/v2`;
-  } else {
-    log(
-      warn(
-        'No contexts found in kubeconfig file. Using default openAPI type definitions.'
-      )
-    );
-  }
-  // Download the swagger file from the url.
-  const opts: request.Options = {
-    url,
-  };
-  kc.applyToRequest(opts);
+
+  const typeSource = chooseTypeSource();
+  const opts = getOptsForTypeSource(typeSource);
+
+  // Download the swagger file from the options based on type source.
   const out = await request.get(opts);
   const tmp = mkdtempSync(resolve(tmpdir(), 'kpt-init'));
   const swaggerFile = resolve(tmp, 'swagger.json');
@@ -85,6 +65,76 @@ export async function typeCreate(packageDir: string) {
   log(`Generated ${typegenOutDir}`);
 
   log(format.finishMarker(desc));
+}
+
+// chooseTypeSource lets the user choose the source for the kubernetes types and returns
+// numeric choice
+function chooseTypeSource(): number {
+  const defaultTypeSource = 0;
+  const ch = validator.getValidString(
+    () =>
+      question(
+        `> What is the source of OpenAPI document defining the Kubernetes types? This will be used to generate Typescript library (${defaultTypeSource})
+[0] Use built-in document (No cluster required)
+[1] Download the document from a Kubernetes cluster
+Please enter your numeric choice: `
+      ),
+    validator.isEmptyOrMaxInt(1),
+    defaultTypeSource.toString()
+  );
+  log(`Using Type source choice "${ch}".\n`);
+
+  return Number(ch);
+}
+
+// getOptsForTypeSource gets the url request options based on the numeric choice input
+// refer to chooseTypeSource() for choice outcomes
+function getOptsForTypeSource(typeSource: number): request.Options {
+  let url = ``;
+  let opts: request.Options = {
+    url,
+  };
+  switch (typeSource) {
+    case 0:
+      log('Using built-in kubernetes types');
+      url = BUILTIN_OPENAPI_URL;
+      opts = {
+        url,
+      };
+      return opts;
+
+    case 1:
+      // Get the kubeconfig context the user wants to use.
+      const kc = new KubeConfig();
+      kc.loadFromDefault();
+      const contexts = kc.contexts;
+      if (contexts.length == 0) {
+        log(
+          failure(
+            'No contexts found in kubeconfig file. Please set a context entry in kubeconfig.'
+          )
+        );
+        process.exit(1);
+      }
+      const currentContext = kc.currentContext;
+      const contextIdx = chooseContext(contexts, currentContext);
+      const useContext = contexts[contextIdx];
+      const cluster = kc.clusters.find(c => c.name === useContext.cluster);
+      if (!cluster) {
+        throw new Error('Cluster for specified context not found.');
+      }
+      kc.setCurrentContext(useContext.name);
+      // set the url to cluster openAPI if cluster exists
+      url = `${cluster.server}/openapi/v2`;
+      opts = {
+        url,
+      };
+      kc.applyToRequest(opts);
+      return opts;
+
+    default:
+      throw new Error('Invalid choice for Kubernetes types source.');
+  }
 }
 
 function chooseContext(contexts: Context[], currentContext: string): number {


### PR DESCRIPTION
@frankfarzan @prachirp 

This is a follow up PR to https://github.com/GoogleContainerTools/kpt-functions-sdk/pull/160. 

Users can choose source for the types either from built-in or kubeconfig. Here is the question

```
Kubernetes Types used to generate Typescript library (0) +
          [0] Use built-in types (No cluster required)? +
          [1] Select a context from kubeconfig ? +
          Please enter your numeric choice: 
```

Based on answer to this question, the next question to choose the context follows if choice is [1].