### PR TITLE
Add support for any JSON type when suggesting values in Results

### DIFF
--- a/ts/kpt-functions/src/io_test.ts
+++ b/ts/kpt-functions/src/io_test.ts
@@ -466,6 +466,68 @@ results:
   severity: error
 `);
     });
+
+    it('has results with object typed suggested values', () => {
+      const configs = new Configs();
+      configs.addResults({
+        message: 'hello',
+        severity: 'error',
+        field: {
+          path: 'foo',
+          currentValue: { a: 3 },
+          suggestedValue: { a: 4 },
+        },
+      });
+
+      const result = stringify(configs, FileFormat.YAML);
+
+      expect(result).toEqual(`apiVersion: v1
+kind: ResourceList
+metadata:
+  name: output
+items: []
+results:
+- message: hello
+  severity: error
+  field:
+    path: foo
+    currentValue:
+      a: 3
+    suggestedValue:
+      a: 4
+`);
+    });
+
+    it('has results with array typed suggested values', () => {
+      const configs = new Configs();
+      configs.addResults({
+        message: 'hello',
+        severity: 'error',
+        field: {
+          path: 'foo',
+          currentValue: [3],
+          suggestedValue: [4],
+        },
+      });
+
+      const result = stringify(configs, FileFormat.YAML);
+
+      expect(result).toEqual(`apiVersion: v1
+kind: ResourceList
+metadata:
+  name: output
+items: []
+results:
+- message: hello
+  severity: error
+  field:
+    path: foo
+    currentValue:
+    - 3
+    suggestedValue:
+    - 4
+`);
+    });
   });
 
   describe('in JSON format', () => {

--- a/ts/kpt-functions/src/io_test.ts
+++ b/ts/kpt-functions/src/io_test.ts
@@ -528,6 +528,37 @@ results:
     - 4
 `);
     });
+
+    it('has results with null as a suggested value', () => {
+      const configs = new Configs();
+      configs.addResults({
+        message: 'hello',
+        severity: 'error',
+        field: {
+          path: 'foo',
+          // tslint:disable-next-line:no-null-keyword
+          currentValue: null,
+          // tslint:disable-next-line:no-null-keyword
+          suggestedValue: null,
+        },
+      });
+
+      const result = stringify(configs, FileFormat.YAML);
+
+      expect(result).toEqual(`apiVersion: v1
+kind: ResourceList
+metadata:
+  name: output
+items: []
+results:
+- message: hello
+  severity: error
+  field:
+    path: foo
+    currentValue: null
+    suggestedValue: null
+`);
+    });
   });
 
   describe('in JSON format', () => {

--- a/ts/kpt-functions/src/result_test.ts
+++ b/ts/kpt-functions/src/result_test.ts
@@ -139,5 +139,71 @@ describe('Results', () => {
         field: { path: 'x.y.z[0]', currentValue: 1, suggestedValue: 2 },
       });
     });
+
+    it('supports object-typed value suggestions', () => {
+      const e = kubernetesObjectResult('hello', someObject, {
+        path: 'x.y.z[0]',
+        currentValue: {
+          w: 0,
+          v: false,
+        },
+        suggestedValue: {
+          w: 1,
+          v: 'hi',
+        },
+      });
+
+      expect(e).toEqual({
+        message: 'hello',
+        severity: 'error',
+        tags: undefined,
+
+        resourceRef: {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          name: 'foo',
+          namespace: 'bar',
+        },
+        file: { path: undefined, index: undefined },
+        field: {
+          path: 'x.y.z[0]',
+          currentValue: {
+            w: 0,
+            v: false,
+          },
+          suggestedValue: {
+            w: 1,
+            v: 'hi',
+          },
+        },
+      });
+    });
+
+    it('supports array-typed value suggestions', () => {
+      const e = kubernetesObjectResult('hello', someObject, {
+        path: 'x.y.z[0]',
+        currentValue: [1, 'true', false],
+        suggestedValue: [1, true, 'false'],
+      });
+
+      expect(e).toEqual({
+        message: 'hello',
+        severity: 'error',
+        tags: undefined,
+
+        resourceRef: {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          name: 'foo',
+          namespace: 'bar',
+        },
+        file: { path: undefined, index: undefined },
+        field: {
+          path: 'x.y.z[0]',
+          currentValue: [1, 'true', false],
+          suggestedValue: [1, true, 'false'],
+        },
+      });
+    });
   });
 });

--- a/ts/kpt-functions/src/types.ts
+++ b/ts/kpt-functions/src/types.ts
@@ -388,11 +388,11 @@ export type Severity = 'error' | 'warn' | 'info';
 
 interface JsonArray extends Array<Json> {}
 
-interface JsonObject {
+interface JsonMap {
   [field: string]: Json;
 }
 
-type Json = null | boolean | number | string | JsonArray | JsonObject;
+type Json = null | boolean | number | string | JsonArray | JsonMap;
 
 /**
  * Metadata about a specific field in a Kubernetes object.

--- a/ts/kpt-functions/src/types.ts
+++ b/ts/kpt-functions/src/types.ts
@@ -386,6 +386,14 @@ export interface Result {
  */
 export type Severity = 'error' | 'warn' | 'info';
 
+interface JsonArray extends Array<Json> {}
+
+interface JsonObject {
+  [field: string]: Json;
+}
+
+type Json = null | boolean | number | string | JsonArray | JsonObject;
+
 /**
  * Metadata about a specific field in a Kubernetes object.
  */
@@ -394,9 +402,9 @@ export interface FieldInfo {
   // e.g. "spec.template.spec.containers[3].resources.limits.cpu"
   path: string;
   // Current value of the field.
-  currentValue?: string | number | boolean;
+  currentValue?: Json;
   // Proposed value to fix the issue.
-  suggestedValue?: string | number | boolean;
+  suggestedValue?: Json;
 }
 
 function resultToString(result: Result): string {


### PR DESCRIPTION
This is one half of the work needed to support arbitrary value suggestions.  I will follow up with a PR to kustomize as well if needed.  Closes https://github.com/GoogleContainerTools/kpt/issues/747.