### PR TITLE
Avoid emitting YAML back-references in kpt fn output

### DIFF
--- a/ts/kpt-functions/src/io.ts
+++ b/ts/kpt-functions/src/io.ts
@@ -38,6 +38,8 @@ const YAML_STYLE: DumpOptions = {
   skipInvalid: true,
   // unset lineWidth from default of 80 to avoid reformatting
   lineWidth: -1,
+  // avoid refs because many YAML parsers in the k8s ecosystem don't support them
+  noRefs: true,
 };
 
 /**

--- a/ts/kpt-functions/src/types.ts
+++ b/ts/kpt-functions/src/types.ts
@@ -403,13 +403,13 @@ export interface Result {
  */
 export type Severity = 'error' | 'warn' | 'info';
 
-interface JsonArray extends Array<Json> {}
+export interface JsonArray extends Array<Json> {}
 
-interface JsonMap {
+export interface JsonMap {
   [field: string]: Json;
 }
 
-type Json = null | boolean | number | string | JsonArray | JsonMap;
+export type Json = null | boolean | number | string | JsonArray | JsonMap;
 
 /**
  * Metadata about a specific field in a Kubernetes object.

--- a/ts/kpt-functions/src/types.ts
+++ b/ts/kpt-functions/src/types.ts
@@ -403,12 +403,15 @@ export interface Result {
  */
 export type Severity = 'error' | 'warn' | 'info';
 
+/** A plain old JSON array according to ECMA-404. */
 export interface JsonArray extends Array<Json> {}
 
+/** A plain old JSON object/map according to ECMA-404. */
 export interface JsonMap {
   [field: string]: Json;
 }
 
+/** Any plain old JSON value according to ECMA-404. */
 export type Json = null | boolean | number | string | JsonArray | JsonMap;
 
 /**


### PR DESCRIPTION
Avoid using YAML refs because many YAML parsers in the k8s ecosystem don't support them.

Without this change, a typical output from a kpt fn run might look like this:

```yaml
apiVersion: v1
kind: ResourceList
metadata:
  name: output
items:
- apiVersion: v1
  kind: Foo
  metadata:
    name: bar
  spec:
    array: &ref_0
    - &ref_1
      baz: 1
results:
- message: something is wrong
  severity: error
  resourceRef:
    apiVersion: v1
    kind: Foo
    namespace: ''
    name: bar
  file: {}
  field:
    path: spec.array
    currentValue: *ref_0
    suggestedValue:
    - *ref_1
    - baz: 3
```

The usage of `&ref_0` and `*ref_0` breaks many YAML parsers that don't implement that YAML feature.