### PR TITLE
Export yaml style, Update argparse version

### DIFF
--- a/ts/kpt-functions/package-lock.json
+++ b/ts/kpt-functions/package-lock.json
@@ -111,9 +111,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.55.tgz",
-      "integrity": "sha512-Vd6xQUVvPCTm7Nx1N7XHcpX6t047ltm7TgcsOr4gFHjeYgwZevo+V7I1lfzHnj5BT5frztZ42+RTG4MwYw63dw==",
+      "version": "12.12.62",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+      "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg==",
       "dev": true
     },
     "@types/rw": {
@@ -1695,9 +1695,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
       "dev": true
     },
     "spdx-ranges": {
@@ -1902,15 +1902,15 @@
       }
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.10.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.3.tgz",
-      "integrity": "sha512-Lh00i69Uf6G74mvYpHCI9KVVXLcHW/xu79YTvH7Mkc9zyKUeSPz0owW0dguj0Scavns3ZOh3wY63J0Zb97Za2g==",
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.4.tgz",
+      "integrity": "sha512-kBFT3U4Dcj4/pJ52vfjCSfyLyvG9VYYuGYPmrPvAxRw/i7xHiT4VvCev+uiEMcEEiu6UNB6KgWmGtSUYIWScbw==",
       "dev": true,
       "optional": true
     },

--- a/ts/kpt-functions/package-lock.json
+++ b/ts/kpt-functions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kpt-functions",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -81,9 +81,9 @@
       "dev": true
     },
     "@types/argparse": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
-      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.0.tgz",
+      "integrity": "sha512-FFW98gJUgUWGq7ZMd0gJmNRoOPqAaq9oiNqfc/RM6+C5BZKHHuHTwvlU5hrOULIXEfZz3rhw9jakwYe6cqNv3Q==",
       "dev": true
     },
     "@types/jasmine": {
@@ -136,12 +136,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -1017,6 +1014,16 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        }
       }
     },
     "json-parse-even-better-errors": {

--- a/ts/kpt-functions/package.json
+++ b/ts/kpt-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kpt-functions",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "KPT functions framework library",
   "author": "KPT Authors",
   "license": "Apache-2.0",
@@ -29,12 +29,12 @@
     "gen-docs": "typedoc src"
   },
   "dependencies": {
-    "argparse": "^1.0.10",
+    "argparse": "^2.0.1",
     "js-yaml": "^3.14.0",
     "rw": "^1.3.3"
   },
   "devDependencies": {
-    "@types/argparse": "^1.0.36",
+    "@types/argparse": "^2.0.0",
     "@types/jasmine": "^3.5.14",
     "@types/js-yaml": "^3.12.5",
     "@types/lodash": "^4.14.161",

--- a/ts/kpt-functions/package.json
+++ b/ts/kpt-functions/package.json
@@ -21,7 +21,7 @@
     "watch": "tsc --watch",
     "clean": "rm -Rf dist/ node_modules/",
     "lint": "tslint -p package.json && prettier \"src/**\" \"*.json\" --check",
-    "lint-license": "license-checker --onlyAllow 'Apache-2.0;MIT;BSD;BSD-2-Clause;BSD-3-Clause;ISC;CC-BY-3.0;CC0-1.0;Unlicense'",
+    "lint-license": "license-checker --onlyAllow 'Apache-2.0;MIT;BSD;BSD-2-Clause;BSD-3-Clause;ISC;CC-BY-3.0;CC0-1.0;Python-2.0;Unlicense'",
     "format": "prettier \"src/**\" \"*.json\" --write",
     "pretest": "npm run build",
     "test": "jasmine --config=jasmine.json",

--- a/ts/kpt-functions/src/io.ts
+++ b/ts/kpt-functions/src/io.ts
@@ -26,7 +26,7 @@ export enum FileFormat {
   JSON,
 }
 type FilePath = string;
-const YAML_STYLE: DumpOptions = {
+export const YAML_STYLE: DumpOptions = {
   // indentation width to use (in spaces).
   indent: 2,
   // when true, will not add an indentation level to array elements.

--- a/ts/kpt-functions/src/io.ts
+++ b/ts/kpt-functions/src/io.ts
@@ -26,7 +26,7 @@ export enum FileFormat {
   JSON,
 }
 type FilePath = string;
-export const YAML_STYLE: DumpOptions = {
+const YAML_STYLE: DumpOptions = {
   // indentation width to use (in spaces).
   indent: 2,
   // when true, will not add an indentation level to array elements.

--- a/ts/kpt-functions/src/run.ts
+++ b/ts/kpt-functions/src/run.ts
@@ -88,41 +88,41 @@ async function runFn(fn: KptFunc) {
   const parser = new ArgumentParser({
     // Used as placeholder name for all functions.
     prog: 'FUNC',
-    addHelp: true,
+    add_help: true,
     description: `${fn.usage}
 
 ${INVOCATIONS}`,
-    formatterClass: RawTextHelpFormatter,
+    formatter_class: RawTextHelpFormatter,
   });
-  parser.addArgument(['-i', '--input'], {
+  parser.add_argument('-i', '--input', {
     help: 'Path to the input file (if not reading from stdin)',
   });
-  parser.addArgument(['-o', '--output'], {
+  parser.add_argument('-o', '--output', {
     help: 'Path to the output file (if not writing to stdout)',
   });
-  parser.addArgument(['-f', '--function-config'], {
+  parser.add_argument('-f', '--function-config', {
     help:
       'Path to the function configuration file. If specified, ignores "functionConfig" field in the input',
   });
-  parser.addArgument(['-d', '--function-config-literal'], {
+  parser.add_argument('-d', '--function-config-literal', {
     help: `Specify a key and literal value (i.e. mykey=somevalue) to populate a ConfigMap instead of
 specifying a file using --function-config.
 Use this ONLY if the function accepts a ConfigMap.`,
     action: 'append',
     nargs: '*',
   });
-  parser.addArgument('--json', {
+  parser.add_argument('--json', {
     action: 'storeTrue',
     help: 'Input and output files are in JSON instead of YAML',
   });
-  parser.addArgument('--log-to-stderr', {
+  parser.add_argument('--log-to-stderr', {
     action: 'storeTrue',
     help:
       'Emit structured results to stderr in addition to setting".results" field in stdout',
   });
 
   // Parse args.
-  const args = new Map<string, any>(Object.entries(parser.parseArgs()));
+  const args = new Map<string, any>(Object.entries(parser.parse_args()));
   const fileFormat = Boolean(args.get('json'))
     ? FileFormat.JSON
     : FileFormat.YAML;


### PR DESCRIPTION
We should export yaml style so functions like sops can reuse it