### PR TITLE
Upgrade jasmine from 3.5.0 to 3.6.3 and fix broken tests

### DIFF
--- a/ts/demo-functions/package-lock.json
+++ b/ts/demo-functions/package-lock.json
@@ -1042,19 +1042,19 @@
       }
     },
     "jasmine": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
-      "integrity": "sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.6.3.tgz",
+      "integrity": "sha512-Th91zHsbsALWjDUIiU5d/W5zaYQsZFMPTdeNmi8GivZPmAaUAK8MblSG3yQI4VMGC/abF2us7ex60NH1AAIMTA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.4",
-        "jasmine-core": "~3.5.0"
+        "glob": "^7.1.6",
+        "jasmine-core": "~3.6.0"
       }
     },
     "jasmine-core": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz",
-      "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.6.0.tgz",
+      "integrity": "sha512-8uQYa7zJN8hq9z+g8z1bqCfdC8eoDAeVnM5sfqs7KHv9/ifoJ500m018fpFc7RDaO6SWCLCXwo/wPSNcdYTgcw==",
       "dev": true
     },
     "js-tokens": {

--- a/ts/demo-functions/package.json
+++ b/ts/demo-functions/package.json
@@ -35,7 +35,7 @@
     "create-kpt-functions": "^0.17.0",
     "dir-compare": "^2.4.0",
     "fs-extra": "^9.0.1",
-    "jasmine": "^3.5.0",
+    "jasmine": "^3.6.3",
     "license-checker": "^25.0.1",
     "prettier": "2.2.1",
     "tslint": "^6.1.3",

--- a/ts/demo-functions/src/validate_rolebinding_test.ts
+++ b/ts/demo-functions/src/validate_rolebinding_test.ts
@@ -61,7 +61,7 @@ describe(validateRolebinding.name, () => {
   );
 
   it('with banned RoleBindings', async () => {
-    RUNNER.assert(
+    RUNNER.assertCallback(
       new Configs([BANNED_RB], FUNC_CONFIG),
       new Configs([BANNED_RB], FUNC_CONFIG, [
         kubernetesObjectResult(

--- a/ts/demo-functions/src/write_yaml_test.ts
+++ b/ts/demo-functions/src/write_yaml_test.ts
@@ -73,7 +73,7 @@ describe('writeYaml', () => {
     functionConfig.data![SINK_DIR] = tmpDir;
     const configs = new kpt.Configs(input.getAll(), functionConfig);
 
-    expectAsync(writeYaml(configs)).toBeRejectedWithError(Error);
+    await expectAsync(writeYaml(configs)).toBeRejectedWithError(Error);
   });
 
   it("silently makes output directory if it doesn't exist", async () => {


### PR DESCRIPTION
This PR contains the change from #215.
It appears that some test were broken with #215. This PR upgrades jasmine and fixes the broken tests.

