### PR TITLE
Structurally compare js objects rather than YAML

### DIFF
--- a/ts/kpt-functions/src/testing.ts
+++ b/ts/kpt-functions/src/testing.ts
@@ -129,7 +129,7 @@ async function testFn(
   }
 }
 
-function valueOf(configs: Configs): string {
+function valueOf(configs: Configs): Configs {
   const output = configs.toResourceList();
   const yaml = safeDump(output, {
     indent: 2,

--- a/ts/kpt-functions/src/testing.ts
+++ b/ts/kpt-functions/src/testing.ts
@@ -15,7 +15,7 @@
  */
 
 import { Configs, KptFunc } from './types';
-import { safeDump } from 'js-yaml';
+import { safeDump, safeLoad } from 'js-yaml';
 
 /**
  * TestRunner makes it easy to write unit tests for kpt functions.
@@ -131,10 +131,11 @@ async function testFn(
 
 function valueOf(configs: Configs): string {
   const output = configs.toResourceList();
-  return safeDump(output, {
+  const yaml = safeDump(output, {
     indent: 2,
     noArrayIndent: true,
     skipInvalid: true,
     sortKeys: true,
   });
+  return safeLoad(yaml);
 }

--- a/ts/kpt-functions/src/testing.ts
+++ b/ts/kpt-functions/src/testing.ts
@@ -129,7 +129,7 @@ async function testFn(
   }
 }
 
-function valueOf(configs: Configs): Configs {
+function valueOf(configs: Configs): any {
   const output = configs.toResourceList();
   const yaml = safeDump(output, {
     indent: 2,


### PR DESCRIPTION
We are using the TestRunner to test our own kpt functions. For our use-cases, we have found the output of failed test cases to be insufficient in helping us locate the actual problems. That is because the test assertion compares two rendered YAMLs. These YAML strings are simply too long and the testing library (jasmine) truncates the strings, typically before the actual difference has appeared.

With this change, we compare JavaScript objects instead, and the assertion errors show a vastly improved structural diff between the configs. Now, we have been careful here to not change the behavior in terms of when tests succeed or fail. We've done that by still converting the configs to YAML and then converting them back from YAML. For us, this has been working exactly as intended.

@emmmile

# Before vs after
Both before and after the change, diffs are printed like `Expected <foo> to equal <bar>.`. Keep an eye out for the `to equal` part in the _before_ diff below:
```
Expected 'apiVersion: v1
items:
- apiVersion: bigtable.cnrm.cloud.google.com/v1beta1
  kind: BigtableInstance
  metadata:
    name: testtest-bigtable-instance
  spec:
    cluster:
    - clusterId: testtest-gr1-1
      numNodes: 0
      zone: gcp-region1-b
    - clusterId: testtest-gr2-1
      numNodes: 0
      zone: gcp-region2-b
    - clusterId: testtest-gr3-1
      numNodes: 0
      zone: gcp-region3-b
    displayName: testtest-bigtable-instance
- apiVersion: storage.example.com/v1alpha1
  kind: BigtableBackupSchedule
  metadata:
    name: testtest-bigtable-instance
- apiVersion: storage.example.com/v1alpha1
  kind: DatabaseAutoscaler
  metadata:
    name: testtest-gr3-1
  spec:
    configuration:
      pagerdutykey: xyz
      parameters:
        cpuTarget: 0.7
        maxNodes: 100
        minNodes: 5
      strategy: StandardStrategy
      version: v1alpha1
    databaseName: >-
      //bigtable.googleapis.com/projects/my-project/instances/testtest-bigtable-instance/clusters/testtest-gr3- ... to equal 'apiVersion: v1
items:
- apiVersion: bigtable.cnrm.cloud.google.com/v1beta1
  kind: BigtableInstance
  metadata:
    name: testtest-bigtable-instance
  spec:
    cluster:
    - clusterId: testtest-gr1-1
      numNodes: 0
      zone: gcp-region1-b
    - clusterId: testtest-gr2-1
      numNodes: 0
      zone: gcp-region2-b
    - clusterId: testtest-gr3-1
      numNodes: 0
      zone: gcp-region3-b
    displayName: testtest-bigtable-instance
- apiVersion: storage.example.com/v1alpha1
  kind: BigtableBackupSchedule
  metadata:
    name: testtest-bigtable-instance
- apiVersion: storage.example.com/v1alpha1
  kind: DatabaseAutoscaler
  metadata:
    name: testtest-gr3-1
  spec:
    configuration:
      pagerdutykey: xyz
      parameters:
        cpuTarget: 0.7
        maxNodes: 100
        minNodes: 5
      strategy: StandardStrategy
      version: v1alpha1
    databaseName: >-
      //bigtable.googleapis.com/projects/my-project/instances/testtest-bigtable-instance/clusters/testtest-gr3- ....
```
And here's the _after_ diff for the same test case:
```
Expected $.results[0].message = 'Word 'bigtable' in instance name is redundant. Complete blocklist: bigtable,cluster,database,instance.' to equal 'Word 'instance' in instance name is redundant. Complete blocklist: bigtable,cluster,database,instance.'.
Expected $.results[1].message = 'Word 'instance' in instance name is redundant. Complete blocklist: bigtable,cluster,database,instance.' to equal 'Word 'bigtable' in instance name is redundant. Complete blocklist: bigtable,cluster,database,instance.'.
```
The _before_ diff has many issues:
1. Displaying the whole YAML encoding is too verbose.
2. Worst of all, the sheer length of the YAML encoding results in a truncated diff. Notice how the "expected" and "actual" both end with `...`. In this test case (and a majority of cases for us), the differences weren't even in the Kubernetes objects part of the `Configs` objects; they were in the results part. So the displayed, truncated, YAML strings are, in fact, 100% equal. The _before_ diff gives us zero information about differences between "expected" and "actual".
3. Since the whole `Configs` objects are rendered as YAML, Kubernetes objects and results included, the diffing only reports that there is a single difference. In the _after_ diff, we see two differences.

From the _after_ diff, we can conclude that the two results `result[0]` and `result[1]` were simply placed in the wrong order in the `results` array.