### PR TITLE
update the legacy id annotation name to the right one

### DIFF
--- a/ts/kpt-functions/src/metadata.ts
+++ b/ts/kpt-functions/src/metadata.ts
@@ -25,7 +25,7 @@ export const ID_ANNOTATION = `${ANNOTATION_PREFIX}/id`;
 export const LEGACY_ANNOTATION_PREFIX = 'config.kubernetes.io';
 export const LEGACY_SOURCE_PATH_ANNOTATION = `${LEGACY_ANNOTATION_PREFIX}/path`;
 export const LEGACY_SOURCE_INDEX_ANNOTATION = `${LEGACY_ANNOTATION_PREFIX}/index`;
-export const LEGACY_ID_ANNOTATION = `${LEGACY_ANNOTATION_PREFIX}/id`;
+export const LEGACY_ID_ANNOTATION = `config.k8s.io/id`;
 
 /**
  * Add an annotation to a KubernetesObject's metadata. Overwrites the previously existing annotation if it exists.


### PR DESCRIPTION
The prefix of the legacy id annotation is slightly different from the others. This PR updates it to the right one.
Ref: https://github.com/kubernetes-sigs/kustomize/issues/4024

This PR will need to be on top of https://github.com/GoogleContainerTools/kpt-functions-sdk/pull/450 to have the CI passing.