### PR TITLE
fix: print correct container registry on init

### DIFF
--- a/ts/create-kpt-functions/src/cmd/package_create.ts
+++ b/ts/create-kpt-functions/src/cmd/package_create.ts
@@ -73,7 +73,7 @@ function initPackage() {
     validator.isValidDockerRepo,
     defaultDockerRepoBase
   );
-  log(`Using docker repository prefix ${defaultDockerRepoBase}.\n`);
+  log(`Using docker repository prefix ${dockerRepoBase}.\n`);
 
   new Templates([
     {


### PR DESCRIPTION
The init kpt-functions command was always printing the default,
regardless of whether an input was provided. This fixes the behavior to
print the proper value.

fixes: GoogleContainerTools/kpt#2527