### PR TITLE
sdk.AsMain should return fn error

### DIFF
--- a/go/fn/errors.go
+++ b/go/fn/errors.go
@@ -16,7 +16,6 @@ package fn
 
 import (
 	"fmt"
-	"log"
 	"strings"
 )
 
@@ -36,18 +35,4 @@ type ErrOpOrDie struct {
 func (e *ErrOpOrDie) Error() string {
 	return fmt.Sprintf("Resource(apiVersion=%v, kind=%v, Name=%v) has unmatched field type: `%v",
 		e.obj.GetAPIVersion(), e.obj.GetKind(), e.obj.GetName(), strings.Join(e.fields, "/"))
-}
-
-func handlePanic() {
-	if v := recover(); v != nil {
-		if e, ok := v.(ErrOpOrDie); ok {
-			log.Fatalf(e.Error())
-		} else if e, ok := v.(Result); ok {
-			log.Fatalf(e.Error())
-		} else if e, ok := v.(Results); ok {
-			log.Fatalf(e.Error())
-		} else {
-			panic(v)
-		}
-	}
 }

--- a/go/fn/errors.go
+++ b/go/fn/errors.go
@@ -38,9 +38,13 @@ func (e *ErrOpOrDie) Error() string {
 		e.obj.GetAPIVersion(), e.obj.GetKind(), e.obj.GetName(), strings.Join(e.fields, "/"))
 }
 
-func handleOptOrDieErr() {
+func handlePanic() {
 	if v := recover(); v != nil {
 		if e, ok := v.(ErrOpOrDie); ok {
+			log.Fatalf(e.Error())
+		} else if e, ok := v.(Result); ok {
+			log.Fatalf(e.Error())
+		} else if e, ok := v.(Results); ok {
 			log.Fatalf(e.Error())
 		} else {
 			panic(v)

--- a/go/fn/examples/example_builtin_function_test.go
+++ b/go/fn/examples/example_builtin_function_test.go
@@ -12,9 +12,9 @@ import (
 
 type RemoveAllResources struct{}
 
-func (*RemoveAllResources) Process(rl *fn.ResourceList) error {
+func (*RemoveAllResources) Process(rl *fn.ResourceList) (bool, error) {
 	rl.Items = nil
-	return nil
+	return true, nil
 }
 
 func Example_builtinFunction() {

--- a/go/fn/examples/example_filter_GVK_test.go
+++ b/go/fn/examples/example_filter_GVK_test.go
@@ -29,9 +29,9 @@ func Example_filterGVK() {
 }
 
 // updateReplicas sets a field in resources selecting by GVK.
-func updateReplicas(rl *fn.ResourceList) error {
+func updateReplicas(rl *fn.ResourceList) (bool, error) {
 	if rl.FunctionConfig == nil {
-		return fn.ErrMissingFnConfig{}
+		return false, fn.ErrMissingFnConfig{}
 	}
 	var replicas int
 	rl.FunctionConfig.GetOrDie(&replicas, "replicas")
@@ -40,5 +40,5 @@ func updateReplicas(rl *fn.ResourceList) error {
 			rl.Items[i].SetOrDie(replicas, "spec", "replicas")
 		}
 	}
-	return nil
+	return true, nil
 }

--- a/go/fn/examples/example_generator_test.go
+++ b/go/fn/examples/example_generator_test.go
@@ -36,16 +36,16 @@ func Example_generator() {
 }
 
 // generate generates a ConfigMap.
-func generate(rl *fn.ResourceList) error {
+func generate(rl *fn.ResourceList) (bool, error) {
 	if rl.FunctionConfig == nil {
-		return fn.ErrMissingFnConfig{}
+		return false, fn.ErrMissingFnConfig{}
 	}
 
 	revision := rl.FunctionConfig.GetStringOrDie("data", "revision")
 	id := rl.FunctionConfig.GetStringOrDie("data", "id")
 	js, err := fetchDashboard(revision, id)
 	if err != nil {
-		return fmt.Errorf("fetch dashboard: %v", err)
+		return false, fmt.Errorf("fetch dashboard: %v", err)
 	}
 
 	cm := corev1.ConfigMap{
@@ -64,7 +64,7 @@ func generate(rl *fn.ResourceList) error {
 			fmt.Sprintf("%v.json", rl.FunctionConfig.GetName()): fmt.Sprintf("%q", js),
 		},
 	}
-	return rl.UpsertObjectToItems(cm, nil, false)
+	return true, rl.UpsertObjectToItems(cm, nil, false)
 }
 
 func fetchDashboard(revision, id string) (string, error) {

--- a/go/fn/examples/example_logger_injector_test.go
+++ b/go/fn/examples/example_logger_injector_test.go
@@ -34,10 +34,10 @@ func Example_loggeInjector() {
 
 // injectLogger injects a logger container into the workload API resources.
 // generate implements the gokrmfn.KRMFunction interface.
-func injectLogger(rl *fn.ResourceList) error {
+func injectLogger(rl *fn.ResourceList) (bool, error) {
 	var li LoggerInjection
 	if err := rl.FunctionConfig.As(&li); err != nil {
-		return err
+		return false, err
 	}
 	for i, obj := range rl.Items {
 		if obj.GetAPIVersion() == "apps/v1" && (obj.GetKind() == "Deployment" || obj.GetKind() == "StatefulSet" || obj.GetKind() == "DaemonSet" || obj.GetKind() == "ReplicaSet") {
@@ -61,7 +61,7 @@ func injectLogger(rl *fn.ResourceList) error {
 			rl.Items[i].SetOrDie(containers, "spec", "template", "spec", "containers")
 		}
 	}
-	return nil
+	return true, nil
 }
 
 // LoggerInjection is type definition of the functionConfig.

--- a/go/fn/examples/example_mutate_comments_test.go
+++ b/go/fn/examples/example_mutate_comments_test.go
@@ -31,14 +31,14 @@ func Example_dMutateComments() {
 	}
 }
 
-func mutateComments(rl *fn.ResourceList) error {
+func mutateComments(rl *fn.ResourceList) (bool, error) {
 	for i := range rl.Items {
 		lineComment, found, err := rl.Items[i].LineComment("metadata", "name")
 		if err != nil {
-			return err
+			return false, err
 		}
 		if !found {
-			return nil
+			return true, nil
 		}
 
 		if strings.TrimSpace(lineComment) == "" {
@@ -47,8 +47,8 @@ func mutateComments(rl *fn.ResourceList) error {
 			lineComment = strings.Replace(lineComment, "foo", "bar", -1)
 		}
 		if err = rl.Items[i].SetLineComment(lineComment, "metadata", "name"); err != nil {
-			return err
+			return false, err
 		}
 	}
-	return nil
+	return true, nil
 }

--- a/go/fn/examples/example_read_field_test.go
+++ b/go/fn/examples/example_read_field_test.go
@@ -28,7 +28,7 @@ func Example_aReadField() {
 	}
 }
 
-func readField(rl *fn.ResourceList) error {
+func readField(rl *fn.ResourceList) (bool, error) {
 	for _, obj := range rl.Items {
 		if obj.GetAPIVersion() == "apps/v1" && obj.GetKind() == "Deployment" {
 			var replicas int
@@ -36,5 +36,5 @@ func readField(rl *fn.ResourceList) error {
 			fn.Logf("replicas is %v\n", replicas)
 		}
 	}
-	return nil
+	return true, nil
 }

--- a/go/fn/examples/example_read_functionConfig_test.go
+++ b/go/fn/examples/example_read_functionConfig_test.go
@@ -30,11 +30,11 @@ func Example_bReadFunctionConfig() {
 	}
 }
 
-func readFunctionConfig(rl *fn.ResourceList) error {
+func readFunctionConfig(rl *fn.ResourceList) (bool, error) {
 	var sr SetReplicas
 	rl.FunctionConfig.AsOrDie(&sr)
 	fn.Logf("desired replicas is %v\n", sr.DesiredReplicas)
-	return nil
+	return true, nil
 }
 
 // SetReplicas is the type definition of the functionConfig

--- a/go/fn/examples/example_set_field_test.go
+++ b/go/fn/examples/example_set_field_test.go
@@ -28,12 +28,12 @@ func Example_cSetField() {
 	}
 }
 
-func setField(rl *fn.ResourceList) error {
+func setField(rl *fn.ResourceList) (bool, error) {
 	for _, obj := range rl.Items {
 		if obj.GetAPIVersion() == "apps/v1" && obj.GetKind() == "Deployment" {
 			replicas := 10
 			obj.SetOrDie(&replicas, "spec", "replicas")
 		}
 	}
-	return nil
+	return true, nil
 }

--- a/go/fn/examples/example_validator_test.go
+++ b/go/fn/examples/example_validator_test.go
@@ -29,7 +29,7 @@ func Example_validator() {
 	}
 }
 
-func validator(rl *fn.ResourceList) error {
+func validator(rl *fn.ResourceList) (bool, error) {
 	var results fn.Results
 	for _, obj := range rl.Items {
 		if obj.GetAPIVersion() == "apps/v1" && (obj.GetKind() == "Deployment" || obj.GetKind() == "StatefulSet" || obj.GetKind() == "DaemonSet" || obj.GetKind() == "ReplicaSet") {
@@ -40,5 +40,5 @@ func validator(rl *fn.ResourceList) error {
 			}
 		}
 	}
-	return results
+	return true, results
 }

--- a/go/fn/resourcelist.go
+++ b/go/fn/resourcelist.go
@@ -200,13 +200,14 @@ func (rl *ResourceList) LogResult(err error) {
 	if err == nil {
 		return
 	}
-	if results, ok := err.(Results); ok {
-		rl.Results = append(rl.Results, results...)
-	} else if result, ok := err.(Result); ok {
+	switch result := err.(type) {
+	case Results:
+		rl.Results = append(rl.Results, result...)
+	case Result:
 		rl.Results = append(rl.Results, &result)
-	} else if result, ok := err.(*Result); ok {
+	case *Result:
 		rl.Results = append(rl.Results, result)
-	} else {
+	default:
 		rl.Results = append(rl.Results, ErrorResult(err))
 	}
 }

--- a/go/fn/run.go
+++ b/go/fn/run.go
@@ -57,21 +57,13 @@ func Run(p ResourceListProcessor, input []byte) (out []byte, err error) {
 		// and return the ResourceList and error.
 		v := recover()
 		if v != nil {
-			if e, ok := v.(ErrOpOrDie); ok {
-				err = fmt.Errorf(e.Error())
-				rl.LogResult(err)
-				out, _ = rl.ToYAML()
-			} else if e, ok := v.(Result); ok {
-				err = fmt.Errorf(e.Message)
-				rl.LogResult(err)
-				out, _ = rl.ToYAML()
-			} else if e, ok := v.(Results); ok {
-				err = fmt.Errorf(e.Error())
-				rl.LogResult(err)
-				out, _ = rl.ToYAML()
+			if e, ok := v.(error); ok {
+				err = e
 			} else {
-				panic(v)
+				err = fmt.Errorf("panic with %v", v)
 			}
+			rl.LogResult(err)
+			out, _ = rl.ToYAML()
 		}
 	}()
 	success, fnErr := p.Process(rl)

--- a/go/fn/run.go
+++ b/go/fn/run.go
@@ -34,6 +34,10 @@ func AsMain(p ResourceListProcessor) error {
 	}
 	out, err := Run(p, in)
 	if err != nil {
+		_, outErr := os.Stdout.Write(out)
+		if outErr != nil {
+			return outErr
+		}
 		return err
 	}
 	_, err = os.Stdout.Write(out)
@@ -61,7 +65,11 @@ func Run(p ResourceListProcessor, input []byte) ([]byte, error) {
 			rl.Results = append(rl.Results, ErrorResult(err))
 		}
 	}
-	return rl.ToYAML()
+	out, yamlErr := rl.ToYAML()
+	if yamlErr != nil {
+		return out, yamlErr
+	}
+	return out, rl.Results
 }
 
 func Execute(p ResourceListProcessor, r io.Reader, w io.Writer) error {


### PR DESCRIPTION
Discovered the root cause of https://github.com/GoogleContainerTools/kpt/issues/2901

In the function SDK `Run` function, the error returned by `Process` is not returned back to `AsMain`. As a result, the function executes "successfully" and kpt does not report the function failure.

In the function SDK `AsMain` function, if `Run` returns an error, we do not get the results from the ResourceList because the ResourceList is not written back to stdout.

This PR fixes the problem in the SDK. 

I have another PR (https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/782) that fixes the problem in apply-replacements.

Before: 

```
Package "apply-replacements-error": 
[RUNNING] "gcr.io/kpt-fn/apply-replacements:unstable"
[PASS] "gcr.io/kpt-fn/apply-replacements:unstable" in 1.1s
  Results:
    [error]: nothing selected by Pod.[noVer].[noGrp]/my-po.[noNs]:spec
```

After:

```
Package "apply-replacements-error": 
[RUNNING] "gcr.io/kpt-fn/apply-replacements:unstable"
[FAIL] "gcr.io/kpt-fn/apply-replacements:unstable" in 1.1s
  Results:
    [error]: nothing selected by Pod.[noVer].[noGrp]/my-po.[noNs]:spec
  Exit code: 1
```
