### PR TITLE
Rename GetString to GetNestedString

### DIFF
--- a/go/fn/examples/example_generator_test.go
+++ b/go/fn/examples/example_generator_test.go
@@ -41,8 +41,8 @@ func generate(rl *fn.ResourceList) error {
 		return fn.ErrMissingFnConfig{}
 	}
 
-	revision := rl.FunctionConfig.GetStringOrDie("data", "revision")
-	id := rl.FunctionConfig.GetStringOrDie("data", "id")
+	revision := rl.FunctionConfig.GetNestedStringOrDie("data", "revision")
+	id := rl.FunctionConfig.GetNestedStringOrDie("data", "id")
 	js, err := fetchDashboard(revision, id)
 	if err != nil {
 		return fmt.Errorf("fetch dashboard: %v", err)

--- a/go/fn/object.go
+++ b/go/fn/object.go
@@ -56,17 +56,17 @@ func (o *KubeObject) GetOrDie(ptr interface{}, fields ...string) {
 	}
 }
 
-// GetString returns the string value, if the field exist and a potential error.
-func (o *KubeObject) GetString(fields ...string) (string, bool, error) {
+// GetNestedString returns the string value, if the field exist and a potential error.
+func (o *KubeObject) GetNestedString(fields ...string) (string, bool, error) {
 	var val string
 	found, err := o.Get(&val, fields...)
 	return val, found, err
 }
 
-// GetStringOrDie returns the string value at fields. An empty string will be
+// GetNestedStringOrDie returns the string value at fields. An empty string will be
 // returned if the field is not found. It will panic if encountering any errors.
-func (o *KubeObject) GetStringOrDie(fields ...string) string {
-	val, _, err := o.GetString(fields...)
+func (o *KubeObject) GetNestedStringOrDie(fields ...string) string {
+	val, _, err := o.GetNestedString(fields...)
 	if err != nil {
 		panic(ErrOpOrDie{obj: o, fields: fields})
 	}


### PR DESCRIPTION
This better matches the unstructured helper names, and frees up the
name for SetString(k,v) - which would otherwise be SetString(v, k...)
