### PR TITLE
Move GetString to SubObject

### DIFF
--- a/go/fn/object.go
+++ b/go/fn/object.go
@@ -57,7 +57,7 @@ func (o *KubeObject) GetOrDie(ptr interface{}, fields ...string) {
 }
 
 // GetString returns the string value, if the field exist and a potential error.
-func (o *KubeObject) GetString(fields ...string) (string, bool, error) {
+func (o *SubObject) GetString(fields ...string) (string, bool, error) {
 	var val string
 	found, err := o.Get(&val, fields...)
 	return val, found, err


### PR DESCRIPTION
This makes it available on KubeObject and SubObject.

We can't move GetStringOrDie because the error needs a reference to
the KubeObject, which SubObject does not currently have.
