### PR TITLE
Use go sdk like unstructured.Unstructured 

### DIFF
--- a/go/fn/examples/example_generator_test.go
+++ b/go/fn/examples/example_generator_test.go
@@ -41,8 +41,8 @@ func generate(rl *fn.ResourceList) (bool, error) {
 		return false, fn.ErrMissingFnConfig{}
 	}
 
-	revision := rl.FunctionConfig.GetStringOrDie("data", "revision")
-	id := rl.FunctionConfig.GetStringOrDie("data", "id")
+	revision := rl.FunctionConfig.NestedStringOrDie("data", "revision")
+	id := rl.FunctionConfig.NestedStringOrDie("data", "id")
 	js, err := fetchDashboard(revision, id)
 	if err != nil {
 		return false, fmt.Errorf("fetch dashboard: %v", err)

--- a/go/fn/examples/example_test.go
+++ b/go/fn/examples/example_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 func ExampleKubeObject_mutatePrimitiveField() {
-	replicas, found, err := deployment.GetInt("spec", "replicas")
+	replicas, found, err := deployment.NestedInt64("spec", "replicas")
 	if err != nil { /* do something */
 	}
 	if !found { /* do something */
@@ -34,7 +34,7 @@ func ExampleKubeObject_mutatePrimitiveField() {
 
 	// mutate the replicas variable
 
-	err = deployment.Set(&replicas, "spec", "replicas")
+	err = deployment.SetNestedField(&replicas, "spec", "replicas")
 	if err != nil { /* do something */
 	}
 }
@@ -49,7 +49,7 @@ func ExampleKubeObject_mutatePrimitiveSlice() {
 
 	// mutate the finalizers slice
 
-	err = deployment.Set(finalizers, "metadata", "finalizers")
+	err = deployment.SetNestedField(finalizers, "metadata", "finalizers")
 	if err != nil { /* do something */
 	}
 }
@@ -64,7 +64,7 @@ func ExampleKubeObject_mutatePrimitiveMap() {
 
 	// mutate the data map
 
-	err = deployment.Set(data, "data")
+	err = deployment.SetNestedField(data, "data")
 	if err != nil { /* do something */
 	}
 }
@@ -79,7 +79,7 @@ func ExampleKubeObject_mutateStrongTypedField() {
 
 	// mutate the podTemplate object
 
-	err = deployment.Set(podTemplate, "spec", "template")
+	err = deployment.SetNestedField(podTemplate, "spec", "template")
 	if err != nil { /* do something */
 	}
 }
@@ -94,7 +94,7 @@ func ExampleKubeObject_mutateStrongTypedSlice() {
 
 	// mutate the podTemplate object
 
-	err = deployment.Set(containers, "spec", "template", "spec", "containers")
+	err = deployment.SetNestedField(containers, "spec", "template", "spec", "containers")
 	if err != nil { /* do something */
 	}
 }

--- a/go/fn/subobject.go
+++ b/go/fn/subobject.go
@@ -29,63 +29,39 @@ func (o *SubObject) UpsertMap(k string) *SubObject {
 	return &SubObject{obj: m}
 }
 
+// GetMap accepts a single key `k` whose value is expected to be a map. It returns
+// the map in the form of a SubObject pointer.
+// It panic with ErrSubObjectFields error if the field cannot be represented as a SubObject.
 func (o *SubObject) GetMap(k string) *SubObject {
-	m := o.obj.GetMap(k)
-	if m == nil {
-		return nil
-	}
-	return &SubObject{obj: m}
+	return o.NestedMapOrDie(k)
+}
+
+// GetBool accepts a single key `k` whose value is expected to be a boolean. It returns
+// the int value of the `k`. It panic with ErrSubObjectFields error if the
+// field is not an integer type.
+func (o *SubObject) GetBool(k string) bool {
+	return o.NestedBoolOrDie(k)
+}
+
+// GetInt accepts a single key `k` whose value is expected to be an integer. It returns
+// the int value of the `k`. It panic with ErrSubObjectFields error if the
+// field is not an integer type.
+func (o *SubObject) GetInt(k string) int64 {
+	return o.NestedInt64OrDie(k)
+}
+
+// GetString accepts a single key `k` whose value is expected to be a string. It returns
+// the value of the `k`. It panic with ErrSubObjectFields error if the
+// field is not a string type.
+func (o *SubObject) GetString(k string) string {
+	return o.NestedStringOrDie(k)
 }
 
 // GetSlice accepts a single key `k` whose value is expected to be a slice. It returns
 // the value as a slice of SubObject. It panic with ErrSubObjectFields error if the
 // field is not a slice type.
 func (o *SubObject) GetSlice(k string) SliceSubObjects {
-	return o.GetSliceNOrDie(k)
-}
-
-// GetSliceN accepts a slice of `fields` which represents the path to the slice component and
-// return a slice of SubObjects as the first return value; whether the component exists or
-// not as the second return value, and errors as the third return value.
-func (o *SubObject) GetSliceN(fields ...string) (SliceSubObjects, bool, error) {
-	var mapVariant *internal.MapVariant
-	if len(fields) > 1 {
-		m, found, err := o.obj.GetNestedMap(fields[:len(fields)-1]...)
-		if err != nil || !found {
-			return nil, found, err
-		}
-		mapVariant = m
-	} else {
-		mapVariant = o.obj
-	}
-	sliceVal, found, err := mapVariant.GetNestedSlice(fields[len(fields)-1])
-	if err != nil {
-		panic(ErrSubObjectFields{fields: fields})
-	}
-	if !found {
-		return nil, found, nil
-	}
-	objects, err := sliceVal.Elements()
-	if err != nil {
-		return nil, found, err
-	}
-	var val []*SubObject
-	for _, obj := range objects {
-		val = append(val, &SubObject{obj: obj})
-	}
-	return val, true, nil
-}
-
-// GetSliceN accepts a slice of `fields` which represents the path to the slice component and
-// return a slice of SubObjects.
-// - It returns nil if the fields does not exist.
-// - It panics with ErrSubObjectFields error if the field is not a slice type.
-func (o *SubObject) GetSliceNOrDie(fields ...string) SliceSubObjects {
-	val, _, err := o.GetSliceN(fields...)
-	if err != nil {
-		panic(ErrSubObjectFields{fields: fields})
-	}
-	return val
+	return o.NestedSliceOrDie(k)
 }
 
 type SliceSubObjects []*SubObject


### PR DESCRIPTION
This PR proposes two user patterns:
-  a concatenated type-specific get
-  a similar experience as using [`unstructured.Unstructured`](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured#NestedStringMap)  `NestedXXX`

User pattern #1:
```go
// o is KubeObject of KCC resource apiVersion: serviceusage.cnrm.cloud.google.com, kind: Service
   externalString := o.GetMap("spec").GetMap("projectRef").GetString("external")
}
```

User pattern #2
```go
// o is KubeObject of KCC resource apiVersion: serviceusage.cnrm.cloud.google.com, kind: Service
   externalString := o.NestedString("spec", "projectRef", "external")
}
``` 

- Added type support for int64, float64, boolean, map
- Change `GetXXX(fields... string)` to  `NestedXXX(fields...string)`
- Add `NestedXXXOrDie` to handle bad type inside the SDK as `ErrSubObjectFields`
- Add `GetXXX(k string)` which accept single key field.

TODO:
- support `SetXXX` and `SetNestedXXX`
- We eventually might surface more functions from `internal.MapVariant` or `internal.SliceVariant`, but now we lean towards completely hiding the `yaml.Node` from users.