### PR TITLE
fn sdk should not try to set id annotations

### DIFF
--- a/go/fn/run.go
+++ b/go/fn/run.go
@@ -86,8 +86,13 @@ func Run(p ResourceListProcessor, input []byte) (out []byte, err error) {
 func Execute(p ResourceListProcessor, r io.Reader, w io.Writer) error {
 	rw := &byteReadWriter{
 		kio.ByteReadWriter{
-			Reader:                r,
-			Writer:                w,
+			Reader: r,
+			Writer: w,
+			// We should not set the id annotation in the function, since we should not
+			// overwrite what the orchestrator set.
+			OmitReaderAnnotations: true,
+			// We should not remove the id annotations in the function, since the
+			// orchestrator (e.g. kpt) may need them.
 			KeepReaderAnnotations: true,
 		},
 	}


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/kustomize/blob/22b735885a5ed4e038b9c8e98fc261cd39d96193/kyaml/kio/byteio_reader.go#L32-L34