### PR TITLE
Check resource duplication by GVKNN

### DIFF
--- a/go/fn/resourcelist.go
+++ b/go/fn/resourcelist.go
@@ -57,6 +57,21 @@ type ResourceList struct {
 	Results Results `yaml:"results,omitempty" json:"results,omitempty"`
 }
 
+// CheckResourceDuplication checks the GVKNN of resourceList.items to make sure they are unique. It returns errors if
+// found more than one resource having the same GVKNN.
+func CheckResourceDuplication(rl *ResourceList) error {
+	idMap := map[yaml.ResourceIdentifier]struct{}{}
+	for _, obj := range rl.Items {
+		id := obj.resourceIdentifier()
+		if _, ok := idMap[*id]; ok{
+				return fmt.Errorf("duplicate Resource(apiVersion=%v, kind=%v, Namespace=%v, Name=%v)",
+				obj.GetAPIVersion(), obj.GetKind(), obj.GetNamespace(), obj.GetName())
+		}
+		idMap[*id] = struct{}{}
+	}
+	return nil
+}
+
 // ParseResourceList parses a ResourceList from the input byte array.
 func ParseResourceList(in []byte) (*ResourceList, error) {
 	rl := &ResourceList{}

--- a/go/fn/resourcelist_test.go
+++ b/go/fn/resourcelist_test.go
@@ -1,0 +1,29 @@
+package fn
+
+import "testing"
+
+var dupResourceInput = []byte(`
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: example
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: example
+`)
+
+func TestCheckResourceDuplication(t *testing.T) {
+	rl, _ := ParseResourceList(dupResourceInput)
+	err := CheckResourceDuplication(rl)
+	if err == nil {
+		t.Errorf("expect to received duplicate error: got nil")
+	}
+	expectErr := "duplicate Resource(apiVersion=v1, kind=Namespace, Namespace=, Name=example)"
+	if err.Error() != expectErr {
+		t.Errorf("expect CheckResourceDuplication to fail; got %v, want %v", err ,expectErr)
+	}
+}

--- a/go/fn/run.go
+++ b/go/fn/run.go
@@ -58,8 +58,12 @@ func Run(p ResourceListProcessor, input []byte) (out []byte, err error) {
 		v := recover()
 		if v != nil {
 			switch t := v.(type) {
+			case ErrKubeObjectFields:
+				err = &t
 			case *ErrKubeObjectFields:
 				err = t
+			case ErrSubObjectFields:
+				err = &t
 			case *ErrSubObjectFields:
 				err = t
 			default:


### PR DESCRIPTION
This function can be used after function evaluation to make sure the change won't introduce duplicate resource. 

See usage here https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/844/files#diff-2b0b1f52afe9e1c4943996b7c2f696f3b641bfc6e0e5beef48d273e72b2b9d19R43