### PR TITLE
Initialize resourcelist.functionConfig even if it's empty.

### DIFF
--- a/go/fn/internal/map.go
+++ b/go/fn/internal/map.go
@@ -46,6 +46,7 @@ type MapVariant struct {
 	node *yaml.Node
 }
 
+
 func (o *MapVariant) GetKind() variantKind {
 	return variantKindMap
 }

--- a/go/fn/object_test.go
+++ b/go/fn/object_test.go
@@ -1,6 +1,8 @@
 package fn
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestIsNamespaceScoped(t *testing.T) {
 	testdata := map[string]struct{
@@ -56,6 +58,77 @@ metadata:
 		o, _ := ParseKubeObject(data.input)
 		if o.IsNamespaceScoped() != data.expected {
 			t.Errorf("%v failed, resource namespace scope: got %v, want  %v", description, o.IsNamespaceScoped(), data.expected)
+		}
+	}
+}
+
+var noFnConfigResourceList = []byte(`apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+`)
+func TestNilFnConfigResourceList(t *testing.T) {
+	rl, _ := ParseResourceList(noFnConfigResourceList)
+	if rl.FunctionConfig == nil	{
+		t.Errorf("Empty functionConfig in ResourceList should still be initialized to avoid nil pointer error")
+	}
+	if !rl.FunctionConfig.IsEmpty() {
+		t.Errorf("The dummy fnConfig should be surfaced and checkable.")
+	}
+	// Check that FunctionConfig should be able to call KRM methods even if its Nil"
+	{
+		if rl.FunctionConfig.GetKind() != "" {
+			t.Errorf("Nil KubeObject cannot call GetKind()")
+		}
+		if rl.FunctionConfig.GetAPIVersion() != "" {
+			t.Errorf("Nil KubeObject cannot call GetAPIVersion()")
+		}
+		if rl.FunctionConfig.GetName() != "" {
+			t.Errorf("Nil KubeObject cannot call GetName()")
+		}
+		if rl.FunctionConfig.GetNamespace() != "" {
+			t.Errorf("Nil KubeObject cannot call GetNamespace()")
+		}
+		if rl.FunctionConfig.GetAnnotation("X") != "" {
+			t.Errorf("Nil KubeObject cannot call GetAnnotation()")
+		}
+		if rl.FunctionConfig.GetLabel("Y") != "" {
+			t.Errorf("Nil KubeObject cannot call GetLabel()")
+		}
+	}
+	// Check that nil FunctionConfig can use SubObject methods.
+	{
+		_, found, err := rl.FunctionConfig.NestedString("not-exist")
+		if found || err != nil {
+			t.Errorf("Nil KubeObject shall not have the field path `not-exist` exist, and not expect errors")
+		}
+	}
+	// Check that nil FunctionConfig should be editable.
+	{
+		rl.FunctionConfig.SetKind("CustomFn")
+		if rl.FunctionConfig.GetKind() != "CustomFn" {
+			t.Errorf("Nil KubeObject cannot call SetKind()")
+		}
+		rl.FunctionConfig.SetAPIVersion("kpt.fn/v1")
+		if rl.FunctionConfig.GetAPIVersion() != "kpt.fn/v1" {
+			t.Errorf("Nil KubeObject cannot call SetAPIVersion()")
+		}
+		rl.FunctionConfig.SetName("test")
+		if rl.FunctionConfig.GetName() != "test" {
+			t.Errorf("Nil KubeObject cannot call SetName()")
+		}
+		rl.FunctionConfig.SetNamespace("test-ns")
+		if rl.FunctionConfig.GetNamespace() != "test-ns" {
+			t.Errorf("Nil KubeObject cannot call SetNamespace()")
+		}
+		rl.FunctionConfig.SetAnnotation("k", "v")
+		if rl.FunctionConfig.GetAnnotation("k") != "v" {
+			t.Errorf("Nil KubeObject cannot call SetAnnotation()")
+		}
+		rl.FunctionConfig.SetLabel("k", "v")
+		if rl.FunctionConfig.GetLabel("k") != "v" {
+			t.Errorf("Nil KubeObject cannot call SetLabel()")
+		}
+		if rl.FunctionConfig.IsEmpty() {
+			t.Errorf("The modified fnConfig is not nil.")
 		}
 	}
 }

--- a/go/fn/resourcelist.go
+++ b/go/fn/resourcelist.go
@@ -88,11 +88,16 @@ func ParseResourceList(in []byte) (*ResourceList, error) {
 	}
 	if found {
 		rl.FunctionConfig = asKubeObject(fc)
+	} else {
+		rl.FunctionConfig = NewEmptyKubeObject()
 	}
 
-	items, _, err := rlObj.obj.GetNestedSlice("items")
+	items, found, err := rlObj.obj.GetNestedSlice("items")
 	if err != nil {
 		return nil, fmt.Errorf("failed when tried to get items: %w", err)
+	}
+	if !found {
+		return rl, nil
 	}
 	objectItems, err := items.Elements()
 	if err != nil {
@@ -134,8 +139,7 @@ func (rl *ResourceList) toYNode() (*yaml.Node, error) {
 			return nil, err
 		}
 	}
-
-	if rl.FunctionConfig != nil {
+	if !rl.FunctionConfig.IsEmpty() {
 		if err := reMap.SetNestedMap(rl.FunctionConfig.node(), "functionConfig"); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Updates
Instead of using a YNode `NodeTagNull` tag, we use an empty `MapNode` YNode. This saves the krm resource level `IsNull` check.

### Description
This PR allows KRM fn to parse, call and modify empty function config.  

### Changes
- `parseResourceList` always initialize functionConfig to `KubeObject` even if the functionConfig is empty.  
   - Reason: from krm fn author side, the functionConfig should be considered as a KRM resource.
   - Usage: From users side, they can check whether a functionConfig is empty via `resourceslist.functionConfig.IsDummy()` 

- A special KubeObject is introduced, which `internal.MapVariant` is referring to a  `NodeTagNull` YNode.
  - Reason: empty functionConfig can use this Dummy `KubeObject` and smoothly get KRM specific info like typeMeta and nameMeta via `GetKind` `GetNamespace` `GetApiVersion` etc. If the functiononfig is nil, those values are empty string. Users won't need to deal with error handlings in those cases otherwise it would be tedious code.
  -  Usage:  
 ```
 resourceslist.functionConfig.GetKind() == ""
 resourceslist.functionConfig.IsGVK("v1", "ConfigMap") == false
```

- Support workflow to edit a Nil `KubeObject`. This is done by re-initializing the MapVariant from YNode tag`NodeTagNull` to a `MappingNode` kind whenever a "SetXXX" method is called on the nil KubeObject. This is not specific to empty FunctionConfig, but for KRM fn which generates new resourcelist.items or modify an empty KubeObject item.

