### PR TITLE
Add get-started code as go SDK user guide sample code

### DIFF
--- a/go/get-started/Dockerfile
+++ b/go/get-started/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.17-alpine3.15
+ENV CGO_ENABLED=0
+WORKDIR /go/src/
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o /usr/local/bin/function ./
+FROM alpine:3.15
+COPY --from=0 /usr/local/bin/function /usr/local/bin/function
+ENTRYPOINT ["function"]

--- a/go/get-started/README.md
+++ b/go/get-started/README.md
@@ -1,0 +1,64 @@
+# some-function-name
+
+Note: Please ensure you follow the [kpt doc style guide].
+
+## Overview
+
+<!--mdtogo:Short-->
+
+Explain what this function does in one or two sentences.
+
+<!--mdtogo-->
+
+Describe why the user should care about this function.
+
+What problem does it solve?
+
+Provide some context (e.g. In the `gatekeeper` function, explain what's
+is `Gatekeeper` project)
+
+[//]: <> (Note: The content between `<!--mdtogo:Short-->` and the following
+`<!--mdtogo-->` will be used as the short description for the command.)
+
+<!--mdtogo:Long-->
+
+## Usage
+
+How do I use this function?
+
+Explain what does it do in details.
+
+Is this function meant to be used declaratively, imperatively or both?
+
+### FunctionConfig
+
+Omit this section, if the function doesn't support any `functionConfigs`.
+Otherwise, explain the function config and behavior for this function in detail.
+For each field in the function config, specify:
+
+- An example value
+- Whether it is optional, and if so, the default value
+
+If showing the function orchestrator (e.g. kpt) can make it clear about how to
+use the function, it's recommended to use it.
+
+[//]: <> (Note: The content between `<!--mdtogo:Long-->` and the following
+`<!--mdtogo-->` will be used as the long description for the command.)
+
+<!--mdtogo-->
+
+## Examples
+
+<!--mdtogo:Examples-->
+
+Omit this section if you are providing complete example kpt packages which are
+linked from the catalog site.
+
+Otherwise, provide inline examples in this section.
+
+[//]: <> (Note: The content between `<!--mdtogo:Examples-->` and the following
+`<!--mdtogo-->` will be used as the examples for the command.)
+
+<!--mdtogo-->
+
+[kpt doc style guide]: https://github.com/GoogleContainerTools/kpt/blob/main/docs/style-guides/docs.md

--- a/go/get-started/data/resources.yaml
+++ b/go/get-started/data/resources.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: MyApp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/go/get-started/main.go
+++ b/go/get-started/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
+)
+
+// EDIT THIS FUNCTION!
+// This is the main logic. rl is the input `ResourceList` which has the `FunctionConfig` and `Items` fields.
+// You can modify the `Items` and add result information to `rl.Result`.
+func Run(rl *fn.ResourceList) (bool, error) {
+    // Your code
+}
+
+func main() {
+	// CUSTOMIZE IF NEEDED
+	// `AsMain` accepts a `ResourceListProcessor` interface.
+	// You can explore other `ResourceListProcessor` structs in the SDK or define your own.
+	if err := fn.AsMain(fn.ResourceListProcessorFunc(Run)); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This PR adds a `go/get-started` directory, which is used by the GO SDK kpt.dev book as starting point to write functions. 