### PR TITLE
Add get-started code as starlark SDK user guide sample code

### DIFF
--- a/starlark/get-started/data/resources.yaml
+++ b/starlark/get-started/data/resources.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: MyApp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/starlark/get-started/starlark-fn-config.yaml
+++ b/starlark/get-started/starlark-fn-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata:
+  name: set-annotation
+# EDIT THE SOURCE!
+# This should be your starlark script which preloads the `ResourceList` to `ctx.resource_list`
+source: |
+  for resource in ctx.resource_list["items"]:
+    if resource.get("kind") == "Deployment":
+      resource["metadata"]["annotations"]["managed-by"] = "kpt"


### PR DESCRIPTION
both Go SDK and starlark SDK user guide will use the get-started examples in the kpt-function-sdk repo. 

