### PR TITLE
fix: sortField for map/slice combination

### DIFF
--- a/go/fn/internal/map.go
+++ b/go/fn/internal/map.go
@@ -195,6 +195,18 @@ func (o *MapVariant) sortFields() error {
 }
 
 func sortFields(ynode *yaml.Node) error {
+	if ynode.Kind == yaml.SequenceNode {
+		for _, child := range ynode.Content {
+			if err := sortFields(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if ynode.Kind != yaml.MappingNode {
+		return nil
+	}
+
 	pairs, err := ynodeToYamlKeyValuePairs(ynode)
 	if err != nil {
 		return fmt.Errorf("unable to sort fields in yaml: %w", err)

--- a/go/fn/internal/test/variant_test.go
+++ b/go/fn/internal/test/variant_test.go
@@ -183,6 +183,35 @@ metadata:
 desiredReplicas: 1
 `,
 		},
+		{
+			name: "k8s built in pod type",
+			input: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "container",
+						Image: "test",
+					}},
+				},
+			},
+			expected: `apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+spec:
+  containers:
+  - name: container
+    image: test
+    resources: {}
+status: {}
+`,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Using NewFromTypedObject for e.g. a k8s Deployment resource fails. The reason for this is that the sortFields function in internal/maps expects the map to contain only scalar values or mapping type entries. Sequence/Slices entries lead to an error when the length of the node count is checked for sorting.

65b4725 adds a corresponding test that yields without the fix
```
    variant_test.go:214:
                Error Trace:    variant_test.go:214
                Error:          Received unexpected error:
                                unable to sort fields in yaml: invalid number of nodes: 1
                Test:           TestTypedObjectToMapVariant
```

cbc48fb fixes this by only sorting yaml nodes of the mapping types. If a Sequence type is encountered its entries are checked regarding whether they are of the mapping type to sort them if so.