### PR TITLE
fix: Improve Runner user experience

### DIFF
--- a/go/fn/examples/example_asmain_runner_test.go
+++ b/go/fn/examples/example_asmain_runner_test.go
@@ -30,7 +30,7 @@ type SetLabels struct {
 // `items` is parsed from the STDIN "ResourceList.Items".
 // `functionConfig` is from the STDIN "ResourceList.FunctionConfig". The value has been assigned to the r.Labels
 //  the functionConfig is validated to have kind "SetLabels" and apiVersion "fn.kpt.dev/v1alpha1"
-func (r *SetLabels) Run(ctx *fn.Context, functionConfig *fn.KubeObject, items []*fn.KubeObject) {
+func (r *SetLabels) Run(ctx *fn.Context, functionConfig *fn.KubeObject, items fn.KubeObjects) {
 	for _, o := range items {
 		for k, newLabel := range r.Labels {
 			o.SetLabel(k, newLabel)

--- a/go/fn/examples/example_logger_injector_test.go
+++ b/go/fn/examples/example_logger_injector_test.go
@@ -58,7 +58,6 @@ func injectLogger(rl *fn.ResourceList) (bool, error) {
 			containers = append(containers, c)
 		}
 		rl.Items[i].SetOrDie(containers, "spec", "template", "spec", "containers")
-
 	}
 	return true, nil
 }

--- a/go/fn/functionrunner.go
+++ b/go/fn/functionrunner.go
@@ -15,5 +15,5 @@
 package fn
 
 type Runner interface {
-	Run(context *Context, functionConfig *KubeObject, items []*KubeObject)
+	Run(context *Context, functionConfig *KubeObject, items KubeObjects)
 }

--- a/go/fn/object_test.go
+++ b/go/fn/object_test.go
@@ -170,6 +170,7 @@ spec:
 	}
 
 	for testName, data := range testCases {
+		data := data
 		t.Run(testName+"/resource", func(t *testing.T) {
 			assert.Equal(t, resource.IsGVK(data.group, data.version, data.kind), data.expect)
 		})
@@ -180,7 +181,6 @@ spec:
 			assert.Equal(t, resourceMismatch.IsGVK(data.group, data.version, data.kind), data.expectMismatch)
 		})
 	}
-
 }
 
 func TestIsNamespaceScoped(t *testing.T) {
@@ -414,7 +414,7 @@ func TestSetNestedFields(t *testing.T) {
 func TestInternalAnnotationsUntouchable(t *testing.T) {
 	o := NewEmptyKubeObject()
 	// Verify the "upstream-identifier" annotation cannot be changed via SetNestedStringMap
-	o.SetNestedStringMap(map[string]string{"owner": "kpt"}, "metadata", "annotations")
+	o.SetNestedStringMapOrDie(map[string]string{"owner": "kpt"}, "metadata", "annotations")
 	if stringMapVal := o.NestedStringMapOrDie("metadata", "annotations"); !reflect.DeepEqual(stringMapVal, map[string]string{"owner": "kpt"}) {
 		t.Errorf("annotations cannot be set via SetNestedStringMap, got %v", stringMapVal)
 	}

--- a/go/fn/origin_test.go
+++ b/go/fn/origin_test.go
@@ -34,22 +34,22 @@ metadata:
 `)
 
 func TestOrigin(t *testing.T) {
-	o_noGroup, _ := ParseKubeObject(resource)
-	if o_noGroup.GetOriginId().String() != "|ConfigMap|example|example" {
-		t.Fatalf("GetOriginId() expect %v, got %v", "|ConfigMap|example|example", o_noGroup.GetOriginId())
+	noGroup, _ := ParseKubeObject(resource)
+	if noGroup.GetOriginId().String() != "|ConfigMap|example|example" {
+		t.Fatalf("GetOriginId() expect %v, got %v", "|ConfigMap|example|example", noGroup.GetOriginId())
 	}
-	o_defaultNamespace, _ := ParseKubeObject(resource)
-	if o_defaultNamespace.GetId().String() != "|ConfigMap|default|cm" {
-		t.Fatalf("GetId() expect %v, got %v", "|ConfigMap|default|cm", o_defaultNamespace.GetId())
+	defaultNamespace, _ := ParseKubeObject(resource)
+	if defaultNamespace.GetId().String() != "|ConfigMap|default|cm" {
+		t.Fatalf("GetId() expect %v, got %v", "|ConfigMap|default|cm", defaultNamespace.GetId())
 	}
-	o_sameIdAndOrigin, _ := ParseKubeObject(resourceCustom)
-	if o_sameIdAndOrigin.GetOriginId().String() != o_sameIdAndOrigin.GetId().String() {
+	sameIdAndOrigin, _ := ParseKubeObject(resourceCustom)
+	if sameIdAndOrigin.GetOriginId().String() != sameIdAndOrigin.GetId().String() {
 		t.Fatalf("expect the origin and id the same if upstream-identifier is not given, got OriginID %v, got ID %v",
-			o_sameIdAndOrigin.GetOriginId(), o_sameIdAndOrigin.GetId())
+			sameIdAndOrigin.GetOriginId(), sameIdAndOrigin.GetId())
 	}
-	o_unknownNamespace, _ := ParseKubeObject(resourceCustom)
-	if o_unknownNamespace.GetId().Namespace != UnknownNamespace {
+	unknownNamespace, _ := ParseKubeObject(resourceCustom)
+	if unknownNamespace.GetId().Namespace != UnknownNamespace {
 		t.Fatalf("expect unknown custom resource use namespace %v, got %v",
-			UnknownNamespace, o_unknownNamespace.GetId().Namespace)
+			UnknownNamespace, unknownNamespace.GetId().Namespace)
 	}
 }

--- a/go/fn/run.go
+++ b/go/fn/run.go
@@ -34,6 +34,8 @@ func AsMain(input interface{}) error {
 		switch input := input.(type) {
 		case Runner:
 			p = runnerProcessor{fnRunner: input}
+		case *Runner:
+			p = runnerProcessor{fnRunner: *input}
 		case ResourceListProcessorFunc:
 			p = input
 		default:


### PR DESCRIPTION
- Update Runner interface to use `KubeObjects` which now supports the `Where` `WhereNot` filter functions
- Allow `AsMain` to accept both the `Runner` instance and the pointer to improve user experience.   
  