### PR TITLE
fix: `isLocalConfig`, add function besides original method

### DIFF
--- a/go/fn/object.go
+++ b/go/fn/object.go
@@ -633,6 +633,15 @@ func (o *KubeObject) IsLocalConfig() bool {
 	return true
 }
 
+// IsLocalConfig is a function that can be used by `Where` to filter out local config
+func IsLocalConfig(o *KubeObject) bool {
+	isLocalConfig := o.GetAnnotation(KptLocalConfig)
+	if isLocalConfig == "" || isLocalConfig == "false" {
+		return false
+	}
+	return true
+}
+
 func (o *KubeObject) GetAPIVersion() string {
 	apiVersion, _, _ := o.obj.GetNestedString("apiVersion")
 	return apiVersion

--- a/go/fn/object.go
+++ b/go/fn/object.go
@@ -633,7 +633,7 @@ func (o *KubeObject) IsLocalConfig() bool {
 	return true
 }
 
-// IsLocalConfig is a function that can be used by `Where` to filter out local config
+// IsLocalConfig determines whether a KubeObject (or KRM resource) has the config.kubernetes.io/local-config: true annotation
 func IsLocalConfig(o *KubeObject) bool {
 	isLocalConfig := o.GetAnnotation(KptLocalConfig)
 	if isLocalConfig == "" || isLocalConfig == "false" {

--- a/go/fn/object.go
+++ b/go/fn/object.go
@@ -635,11 +635,7 @@ func (o *KubeObject) IsLocalConfig() bool {
 
 // IsLocalConfig determines whether a KubeObject (or KRM resource) has the config.kubernetes.io/local-config: true annotation
 func IsLocalConfig(o *KubeObject) bool {
-	isLocalConfig := o.GetAnnotation(KptLocalConfig)
-	if isLocalConfig == "" || isLocalConfig == "false" {
-		return false
-	}
-	return true
+	return o.IsLocalConfig()
 }
 
 func (o *KubeObject) GetAPIVersion() string {

--- a/go/fn/object_test.go
+++ b/go/fn/object_test.go
@@ -184,16 +184,17 @@ spec:
 }
 
 func TestIsLocalConfig(t *testing.T) {
-	functionConfig := []byte(`
-apiVersion: fn.kpt.dev/v1alpha1
-kind: SetLabels
+	kptFile := []byte(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
 metadata:
- name: my-config
- annotations:
-   config.kubernetes.io/local-config: "true"
-labels:
- color: orange
- fruit: apple
+  name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-labels:unstable
+      configPath: fn-config.yaml
 `)
 	item := []byte(`
 apiVersion: v1
@@ -204,9 +205,9 @@ metadata:
    app: myApp
 `)
 	rl := &ResourceList{}
-	config, _ := ParseKubeObject(functionConfig)
-	itemObj, _ := ParseKubeObject(item)
-	rl.Items = []*KubeObject{config, itemObj}
+	kptFileItem, _ := ParseKubeObject(kptFile)
+	serviceItem, _ := ParseKubeObject(item)
+	rl.Items = []*KubeObject{kptFileItem, serviceItem}
 	for _, o := range rl.Items.WhereNot(IsLocalConfig) {
 		assert.Equal(t, o.GetString("kind"), "Service")
 	}

--- a/go/fn/object_test.go
+++ b/go/fn/object_test.go
@@ -183,6 +183,35 @@ spec:
 	}
 }
 
+func TestIsLocalConfig(t *testing.T) {
+	functionConfig := []byte(`
+apiVersion: fn.kpt.dev/v1alpha1
+kind: SetLabels
+metadata:
+ name: my-config
+ annotations:
+   config.kubernetes.io/local-config: "true"
+labels:
+ color: orange
+ fruit: apple
+`)
+	item := []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+ name: whatever
+ labels:
+   app: myApp
+`)
+	rl := &ResourceList{}
+	config, _ := ParseKubeObject(functionConfig)
+	itemObj, _ := ParseKubeObject(item)
+	rl.Items = []*KubeObject{config, itemObj}
+	for _, o := range rl.Items.WhereNot(IsLocalConfig) {
+		assert.Equal(t, o.GetString("kind"), "Service")
+	}
+}
+
 func TestIsNamespaceScoped(t *testing.T) {
 	testdata := map[string]struct {
 		input    []byte


### PR DESCRIPTION
`isLocalConfig` is a method of `KubeObject`. Because this usage often comes with `Where` and `WhereNot` functions to work as filters, and `Where` needs a function input, I refactored a function that provides the same logic as the method to facilitate the usage.