### PR TITLE
Add `Results` method and `Context`

### DIFF
--- a/go/fn/context.go
+++ b/go/fn/context.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fn
+
+import (
+	"context"
+	"time"
+)
+
+var _ context.Context = &Context{}
+
+// TODO: Have Context implement `context.Context`.
+type Context struct {
+	ctx context.Context
+}
+
+func (c *Context) Deadline() (deadline time.Time, ok bool) {
+	return c.ctx.Deadline()
+}
+
+func (c *Context) Done() <-chan struct{} {
+	return c.ctx.Done()
+}
+func (c *Context) Err() error {
+	return c.ctx.Err()
+}
+
+func (c *Context) Value(key any) any {
+	return c.ctx.Value(key)
+}

--- a/go/fn/context.go
+++ b/go/fn/context.go
@@ -16,27 +16,11 @@ package fn
 
 import (
 	"context"
-	"time"
 )
 
 var _ context.Context = &Context{}
 
 // TODO: Have Context implement `context.Context`.
 type Context struct {
-	ctx context.Context
-}
-
-func (c *Context) Deadline() (deadline time.Time, ok bool) {
-	return c.ctx.Deadline()
-}
-
-func (c *Context) Done() <-chan struct{} {
-	return c.ctx.Done()
-}
-func (c *Context) Err() error {
-	return c.ctx.Err()
-}
-
-func (c *Context) Value(key any) any {
-	return c.ctx.Value(key)
+	context.Context
 }

--- a/go/fn/examples/example_asmain_runner_test.go
+++ b/go/fn/examples/example_asmain_runner_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,14 +29,16 @@ type SetLabels struct {
 // `ctx` provides easy methods to add info, error or warning result to `ResourceList.Results`.
 // `items` is parsed from the STDIN "ResourceList.Items".
 // `functionConfig` is from the STDIN "ResourceList.FunctionConfig". The value has been assigned to the r.Labels
-//  the functionConfig is validated to have kind "SetLabels" and apiVersion "fn.kpt.dev/v1alpha1"
-func (r *SetLabels) Run(ctx *fn.Context, functionConfig *fn.KubeObject, items fn.KubeObjects) {
+//
+//	the functionConfig is validated to have kind "SetLabels" and apiVersion "fn.kpt.dev/v1alpha1"
+func (r *SetLabels) Run(_ *fn.Context, _ *fn.KubeObject, items fn.KubeObjects, results *fn.Results) bool {
 	for _, o := range items {
 		for k, newLabel := range r.Labels {
 			o.SetLabel(k, newLabel)
 		}
 	}
-	ctx.ResultInfo("updated labels", nil)
+	results.Infof("updated labels")
+	return true
 }
 
 // This example uses a SetLabels object, which implements `Runner.Run` methods.
@@ -48,12 +50,14 @@ func (r *SetLabels) Run(ctx *fn.Context, functionConfig *fn.KubeObject, items fn
 //   - apiVersion: v1
 //     kind: Service
 //     metadata:
-//       name: example
+//     name: example
+//
 // functionConfig:
-//   apiVersion: fn.kpt.dev/v1alpha1
-//   kind: SetLabels
-//   metadata:
-//     name: setlabel-fn-config
+//
+//	apiVersion: fn.kpt.dev/v1alpha1
+//	kind: SetLabels
+//	metadata:
+//	  name: setlabel-fn-config
 func Example_asMain() {
 	file, _ := os.Open("./data/setlabels-resourcelist.yaml")
 	defer file.Close()

--- a/go/fn/examples/example_asmain_runner_test.go
+++ b/go/fn/examples/example_asmain_runner_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,31 +14,31 @@
 package example
 
 import (
-    "os"
+	"context"
+	"os"
 
-    "github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
+	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 )
 
 var _ fn.Runner = &SetLabels{}
 
 type SetLabels struct {
-    Labels map[string]string `json:"labels,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // Run is the main function logic.
 // `ctx` provides easy methods to add info, error or warning result to `ResourceList.Results`.
 // `items` is parsed from the STDIN "ResourceList.Items".
 // `functionConfig` is from the STDIN "ResourceList.FunctionConfig". The value has been assigned to the r.Labels
-//
-//    the functionConfig is validated to have kind "SetLabels" and apiVersion "fn.kpt.dev/v1alpha1"
-func (r *SetLabels) Run(_ *fn.Context, _ *fn.KubeObject, items fn.KubeObjects, results *fn.Results) bool {
-    for _, o := range items {
-    for k, newLabel := range r.Labels {
-    o.SetLabel(k, newLabel)
-    }
-    }
-    results.Infof("updated labels")
-    return true
+//  the functionConfig is validated to have kind "SetLabels" and apiVersion "fn.kpt.dev/v1alpha1"
+func (r *SetLabels) Run(ctx *fn.Context, functionConfig *fn.KubeObject, items fn.KubeObjects, results *fn.Results) bool {
+	for _, o := range items {
+		for k, newLabel := range r.Labels {
+			o.SetLabel(k, newLabel)
+		}
+	}
+	results.Infof("updated labels")
+	return true
 }
 
 // This example uses a SetLabels object, which implements `Runner.Run` methods.
@@ -51,34 +51,33 @@ func (r *SetLabels) Run(_ *fn.Context, _ *fn.KubeObject, items fn.KubeObjects, r
 //     kind: Service
 //     metadata:
 //       name: example
-//
 // functionConfig:
-//    apiVersion: fn.kpt.dev/v1alpha1
-//    kind: SetLabels
-//    metadata:
-//      name: setlabel-fn-config
-func Example_asMain() {
-    file, _ := os.Open("./data/setlabels-resourcelist.yaml")
-    defer file.Close()
-    os.Stdin = file
-
-    if err := fn.AsMain(&SetLabels{}); err != nil {
-    os.Exit(1)
-    }
-    // Output:
-    // apiVersion: config.kubernetes.io/v1
-    // kind: ResourceList
-    // items:
-    // - apiVersion: v1
-    //   kind: Service
-    //   metadata:
-    //     name: example
-    // functionConfig:
-    //   apiVersion: fn.kpt.dev/v1alpha1
-    //   kind: SetLabels
-    //   metadata:
-    //     name: setlabel-fn-config
-    // results:
-    // - message: updated labels
-    //   severity: info
+//   apiVersion: fn.kpt.dev/v1alpha1
+//   kind: SetLabels
+//   metadata:
+//     name: setlabel-fn-config
+func main() {
+	file, _ := os.Open("./data/setlabels-resourcelist.yaml")
+	defer file.Close()
+	os.Stdin = file
+	ctx := context.TODO()
+	if err := fn.AsMain(fn.WithContext(ctx, &SetLabels{})); err != nil {
+		os.Exit(1)
+	}
+	// Output:
+	// apiVersion: config.kubernetes.io/v1
+	// kind: ResourceList
+	// items:
+	// - apiVersion: v1
+	//   kind: Service
+	//   metadata:
+	//     name: example
+	// functionConfig:
+	//   apiVersion: fn.kpt.dev/v1alpha1
+	//   kind: SetLabels
+	//   metadata:
+	//     name: setlabel-fn-config
+	// results:
+	// - message: updated labels
+	//   severity: info
 }

--- a/go/fn/examples/example_asmain_runner_test.go
+++ b/go/fn/examples/example_asmain_runner_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,15 +14,15 @@
 package example
 
 import (
-	"os"
+    "os"
 
-	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
+    "github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 )
 
 var _ fn.Runner = &SetLabels{}
 
 type SetLabels struct {
-	Labels map[string]string `json:"labels,omitempty"`
+    Labels map[string]string `json:"labels,omitempty"`
 }
 
 // Run is the main function logic.
@@ -30,15 +30,15 @@ type SetLabels struct {
 // `items` is parsed from the STDIN "ResourceList.Items".
 // `functionConfig` is from the STDIN "ResourceList.FunctionConfig". The value has been assigned to the r.Labels
 //
-//	the functionConfig is validated to have kind "SetLabels" and apiVersion "fn.kpt.dev/v1alpha1"
+//    the functionConfig is validated to have kind "SetLabels" and apiVersion "fn.kpt.dev/v1alpha1"
 func (r *SetLabels) Run(_ *fn.Context, _ *fn.KubeObject, items fn.KubeObjects, results *fn.Results) bool {
-	for _, o := range items {
-		for k, newLabel := range r.Labels {
-			o.SetLabel(k, newLabel)
-		}
-	}
-	results.Infof("updated labels")
-	return true
+    for _, o := range items {
+    for k, newLabel := range r.Labels {
+    o.SetLabel(k, newLabel)
+    }
+    }
+    results.Infof("updated labels")
+    return true
 }
 
 // This example uses a SetLabels object, which implements `Runner.Run` methods.
@@ -50,36 +50,35 @@ func (r *SetLabels) Run(_ *fn.Context, _ *fn.KubeObject, items fn.KubeObjects, r
 //   - apiVersion: v1
 //     kind: Service
 //     metadata:
-//     name: example
+//       name: example
 //
 // functionConfig:
-//
-//	apiVersion: fn.kpt.dev/v1alpha1
-//	kind: SetLabels
-//	metadata:
-//	  name: setlabel-fn-config
+//    apiVersion: fn.kpt.dev/v1alpha1
+//    kind: SetLabels
+//    metadata:
+//      name: setlabel-fn-config
 func Example_asMain() {
-	file, _ := os.Open("./data/setlabels-resourcelist.yaml")
-	defer file.Close()
-	os.Stdin = file
+    file, _ := os.Open("./data/setlabels-resourcelist.yaml")
+    defer file.Close()
+    os.Stdin = file
 
-	if err := fn.AsMain(&SetLabels{}); err != nil {
-		os.Exit(1)
-	}
-	// Output:
-	// apiVersion: config.kubernetes.io/v1
-	// kind: ResourceList
-	// items:
-	// - apiVersion: v1
-	//   kind: Service
-	//   metadata:
-	//     name: example
-	// functionConfig:
-	//   apiVersion: fn.kpt.dev/v1alpha1
-	//   kind: SetLabels
-	//   metadata:
-	//     name: setlabel-fn-config
-	// results:
-	// - message: updated labels
-	//   severity: info
+    if err := fn.AsMain(&SetLabels{}); err != nil {
+    os.Exit(1)
+    }
+    // Output:
+    // apiVersion: config.kubernetes.io/v1
+    // kind: ResourceList
+    // items:
+    // - apiVersion: v1
+    //   kind: Service
+    //   metadata:
+    //     name: example
+    // functionConfig:
+    //   apiVersion: fn.kpt.dev/v1alpha1
+    //   kind: SetLabels
+    //   metadata:
+    //     name: setlabel-fn-config
+    // results:
+    // - message: updated labels
+    //   severity: info
 }

--- a/go/fn/functionrunner.go
+++ b/go/fn/functionrunner.go
@@ -15,5 +15,13 @@
 package fn
 
 type Runner interface {
-	Run(context *Context, functionConfig *KubeObject, items KubeObjects)
+	// Run passes the `functionConfig` and `items` from input ResourceList to allow you to do operations.
+	// Args:
+	//    items: We intentionally do not allow you to add or delete KubeObject from "items", you can only modify
+	// the items, because we expect you to use Runner only for transformer or validator functions.
+	//    results: You can use `ErrorE` `Errorf` `Infof` `Warningf` `WarningE` to add user message to `Results`.
+	// Returns:
+	//    return a boolean to tell whether the execution should be considered as PASS or FAIL. CLI like kpt will
+	// display the corresponding message.
+	Run(context *Context, functionConfig *KubeObject, items KubeObjects, results *Results) bool
 }

--- a/go/fn/functionrunner.go
+++ b/go/fn/functionrunner.go
@@ -15,10 +15,11 @@
 package fn
 
 type Runner interface {
-	// Run passes the `functionConfig` and `items` from input ResourceList to allow you to do operations.
+	// Run provides the entrypoint to allow you make changes to input `resourcelist.Items`
 	// Args:
-	//    items: We intentionally do not allow you to add or delete KubeObject from "items", you can only modify
-	// the items, because we expect you to use Runner only for transformer or validator functions.
+	//    items: The KRM resources in the form of a slice of KubeObject.
+	//       Note: You can only modify the existing items but not add or delete items.
+	//       We intentionally design the method this way to make the Runner be used as a Transformer or Validator, but not a Generator.
 	//    results: You can use `ErrorE` `Errorf` `Infof` `Warningf` `WarningE` to add user message to `Results`.
 	// Returns:
 	//    return a boolean to tell whether the execution should be considered as PASS or FAIL. CLI like kpt will

--- a/go/fn/result.go
+++ b/go/fn/result.go
@@ -130,7 +130,7 @@ type Field struct {
 
 type Results []*Result
 
-// ErrorE writes an Error level `result` to the results slice. It accepts arguments according to a format specifier.
+// Errorf writes an Error level `result` to the results slice. It accepts arguments according to a format specifier.
 // e.g.
 // results.Errorf("bad kind %v", "invalid")
 func (r *Results) Errorf(format string, a ...any) {
@@ -140,7 +140,6 @@ func (r *Results) Errorf(format string, a ...any) {
 
 // ErrorE writes the `error` as an Error level `result` to the results slice.
 // e.g.
-//
 //	err := error.New("test)
 //	results.ErrorE(err)
 func (r *Results) ErrorE(err error) {
@@ -150,7 +149,6 @@ func (r *Results) ErrorE(err error) {
 
 // Infof writes an Info level `result` to the results slice. It accepts arguments according to a format specifier.
 // e.g.
-//
 //	results.Infof("update %v %q ", "ConfigMap", "kptfile.kpt.dev")
 func (r *Results) Infof(format string, a ...any) {
 	infoResult := &Result{Severity: Info, Message: fmt.Sprintf(format, a...)}
@@ -159,7 +157,6 @@ func (r *Results) Infof(format string, a ...any) {
 
 // Warningf writes a Warning level `result` to the results slice. It accepts arguments according to a format specifier.
 // e.g.
-//
 //	results.Warningf("bad kind %q", "invalid")
 func (r *Results) Warningf(format string, a ...any) {
 	warnResult := &Result{Severity: Warning, Message: fmt.Sprintf(format, a...)}

--- a/go/fn/result.go
+++ b/go/fn/result.go
@@ -20,54 +20,6 @@ import (
 	"strings"
 )
 
-// Context provides a series of functions to add `Result` to `ResourceList.Results`.
-type Context struct {
-	results *Results
-}
-
-func (c *Context) Result(message string, severity Severity) {
-	*c.results = append(*c.results, &Result{Message: message, Severity: severity})
-}
-
-// AddErrResultAndDie adds an Error `Result` and terminates the KRM function run. `KubeObject` can be nil.
-func (c *Context) ResultErrAndDie(message string, o *KubeObject) {
-	c.ResultErr(message, o)
-	panic(errResultEnd{obj: o, message: message})
-}
-
-// AddErrResult adds an Error `Result` and continues the KRM function run. `KubeObject` can be nil.
-func (c *Context) ResultErr(message string, o *KubeObject) {
-	var r *Result
-	if o != nil {
-		r = ConfigObjectResult(message, o, Error)
-	} else {
-		r = GeneralResult(message, Error)
-	}
-	*c.results = append(*c.results, r)
-}
-
-// AddErrResult adds an Info `Result`. `KubeObject` can be nil.
-func (c *Context) ResultInfo(message string, o *KubeObject) {
-	var r *Result
-	if o != nil {
-		r = ConfigObjectResult(message, o, Info)
-	} else {
-		r = GeneralResult(message, Info)
-	}
-	*c.results = append(*c.results, r)
-}
-
-// AddErrResult adds an Info `Result`. `KubeObject` can be nil.
-func (c *Context) ResultWarn(message string, o *KubeObject) {
-	var r *Result
-	if o != nil {
-		r = ConfigObjectResult(message, o, Warning)
-	} else {
-		r = GeneralResult(message, Info)
-	}
-	*c.results = append(*c.results, r)
-}
-
 // Severity indicates the severity of the Result
 type Severity string
 
@@ -178,18 +130,69 @@ type Field struct {
 
 type Results []*Result
 
+// ErrorE writes an Error level `result` to the results slice. It accepts arguments according to a format specifier.
+// e.g.
+// results.Errorf("bad kind %v", "invalid")
+func (r *Results) Errorf(format string, a ...any) {
+	errResult := &Result{Severity: Error, Message: fmt.Sprintf(format, a...)}
+	*r = append(*r, errResult)
+}
+
+// ErrorE writes the `error` as an Error level `result` to the results slice.
+// e.g.
+//
+//	err := error.New("test)
+//	results.ErrorE(err)
+func (r *Results) ErrorE(err error) {
+	errResult := &Result{Severity: Error, Message: err.Error()}
+	*r = append(*r, errResult)
+}
+
+// Infof writes an Info level `result` to the results slice. It accepts arguments according to a format specifier.
+// e.g.
+//
+//	results.Infof("update %v %q ", "ConfigMap", "kptfile.kpt.dev")
+func (r *Results) Infof(format string, a ...any) {
+	infoResult := &Result{Severity: Info, Message: fmt.Sprintf(format, a...)}
+	*r = append(*r, infoResult)
+}
+
+// Warningf writes a Warning level `result` to the results slice. It accepts arguments according to a format specifier.
+// e.g.
+//
+//	results.Warningf("bad kind %q", "invalid")
+func (r *Results) Warningf(format string, a ...any) {
+	warnResult := &Result{Severity: Warning, Message: fmt.Sprintf(format, a...)}
+	*r = append(*r, warnResult)
+}
+
+// WarningE writes an error as a Warning level `result` to the results slice.
+// Normally this function can be used for cases that need error tolerance.
+func (r *Results) WarningE(err error) {
+	warnResult := &Result{Severity: Warning, Message: err.Error()}
+	*r = append(*r, warnResult)
+}
+
+func (r *Results) String() string {
+	var results []string
+	for _, result := range *r {
+		results = append(results, result.String())
+	}
+	return strings.Join(results, "\n---\n")
+}
+
 // Error enables Results to be returned as an error
-func (e Results) Error() string {
+func (r Results) Error() string {
 	var msgs []string
-	for _, i := range e {
+	for _, i := range r {
 		msgs = append(msgs, i.String())
 	}
 	return strings.Join(msgs, "\n\n")
 }
 
 // ExitCode provides the exit code based on the result's severity
-func (e Results) ExitCode() int {
-	for _, i := range e {
+func (r Results) ExitCode() int {
+	for _, i := range r {
 		if i.Severity == Error {
 			return 1
 		}
@@ -198,15 +201,15 @@ func (e Results) ExitCode() int {
 }
 
 // Sort performs an in place stable sort of Results
-func (e Results) Sort() {
-	sort.SliceStable(e, func(i, j int) bool {
-		if fileLess(e, i, j) != 0 {
-			return fileLess(e, i, j) < 0
+func (r Results) Sort() {
+	sort.SliceStable(r, func(i, j int) bool {
+		if fileLess(r, i, j) != 0 {
+			return fileLess(r, i, j) < 0
 		}
-		if severityLess(e, i, j) != 0 {
-			return severityLess(e, i, j) < 0
+		if severityLess(r, i, j) != 0 {
+			return severityLess(r, i, j) < 0
 		}
-		return resultToString(*e[i]) < resultToString(*e[j])
+		return resultToString(*r[i]) < resultToString(*r[j])
 	})
 }
 

--- a/go/fn/run.go
+++ b/go/fn/run.go
@@ -31,10 +31,8 @@ func AsMain(input interface{}) error {
 	err := func() error {
 		var p ResourceListProcessor
 		switch input := input.(type) {
-		case Runner:
-			p = runnerProcessor{fnRunner: input}
-		case *Runner:
-			p = runnerProcessor{fnRunner: *input}
+		case runnerProcessor:
+			p = input
 		case ResourceListProcessorFunc:
 			p = input
 		default:

--- a/go/fn/runnerProcessor.go
+++ b/go/fn/runnerProcessor.go
@@ -31,7 +31,7 @@ type runnerProcessor struct {
 }
 
 func (r runnerProcessor) Process(rl *ResourceList) (bool, error) {
-	fnCtx := &Context{ctx: r.ctx}
+	fnCtx := &Context{Context: r.ctx}
 	results := new(Results)
 	if ok := r.config(rl.FunctionConfig, results); !ok {
 		rl.Results = append(rl.Results, *results...)


### PR DESCRIPTION
This PR does 3 jobs
- It adds `Results` methods.
- It allow Context to control the flow.
- It split `results` from previous `context`    