### PR TITLE
Validate FnRunner workflow

### DIFF
--- a/go/fn/runnerProcessor.go
+++ b/go/fn/runnerProcessor.go
@@ -16,6 +16,7 @@ package fn
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,45 +31,88 @@ type runnerProcessor struct {
 	fnRunner Runner
 }
 
-func (r runnerProcessor) Process(rl *ResourceList) (bool, error) {
-	fnCtx := &Context{Context: r.ctx}
-	results := new(Results)
-	if ok := r.config(rl.FunctionConfig, results); !ok {
-		rl.Results = append(rl.Results, *results...)
-		return false, nil
-	}
-	pass := r.fnRunner.Run(fnCtx, rl.FunctionConfig, rl.Items, results)
-	rl.Results = append(rl.Results, *results...)
-	return pass, nil
-}
-
-func (r *runnerProcessor) config(o *KubeObject, results *Results) bool {
-	fnName := reflect.ValueOf(r.fnRunner).Elem().Type().Name()
-	switch true {
-	case o.IsEmpty():
-		results.Infof("`FunctionConfig` is not given")
-	case o.IsGroupKind(schema.GroupKind{Kind: "ConfigMap"}):
-		data, _, err := o.NestedStringMap("data")
-		if err != nil {
-			results.ErrorE(err)
-			return false
-		}
-		fnRunnerElem := reflect.ValueOf(r.fnRunner).Elem()
-		for i := 0; i < fnRunnerElem.NumField(); i++ {
-			if fnRunnerElem.Field(i).Kind() == reflect.Map {
-				fnRunnerElem.Field(i).Set(reflect.ValueOf(data))
-				break
-			}
-		}
-	case o.IsGroupVersionKind(schema.GroupVersionKind{Group: "fn.kpt.dev", Version: "v1alpha1", Kind: fnName}):
-		err := o.As(r.fnRunner)
-		if err != nil {
-			results.ErrorE(err)
-			return false
-		}
-	default:
-		results.Errorf("unknown FunctionConfig `%v`, expect %v", o.GetKind(), fnName)
+// EmptyFunctionConfig is a workaround solution to handle the case where kpt passes in a functionConfig placeholder
+// (Configmap with empty `data`) if user does not provide the actual FunctionConfig. Ideally, kpt should pass in an empty
+// FunctionConfig object.
+func EmptyFunctionConfig(o *KubeObject) bool {
+	data, found, err :=  o.NestedStringMap("data")
+	// Some other type
+	if !found || err != nil {
 		return false
 	}
-	return true
+	return o.GetKind() == "ConfigMap" && o.GetName() == "function-input" && len(data) == 0
+}
+
+// Process assigns the ResourceList.FunctionConfig to Runner's attributes, and calls the Runner.Run methods (main method)
+// to run functions. The r.fnRunner accepts three kinds of functionConfig value:
+// 1. no function config, it only runs fnRunner.Run
+// 2. ConfigMap type, it requires the Runner instance to have one contributes of type map[string]string to receive the ConfigMap `.data` value.
+// 3. Runner type, it uses the Runner struct name as the FunctionConfig Kind. e.g. if the Runner is `SetNamespace`,
+//   the FunctionConfig should be `{"Kind": "SetNamespace", "apiVersion": "fn.kpt.dev/v1alpha1"}
+func (r runnerProcessor) Process(rl *ResourceList) (bool, error) {
+	// Validate and Parse the input FunctionConfig to r.fnRunner
+	if rl.FunctionConfig.IsEmpty() || EmptyFunctionConfig(rl.FunctionConfig){
+		// functions may not need functionConfig.
+		rl.Results.Infof("`FunctionConfig` is not given")
+	} else {
+		err := r.config(rl.FunctionConfig)
+		if err != nil {
+			rl.Results.ErrorE(err)
+			return false, nil
+		}
+	}
+	// Run the main function.
+	fnCtx := &Context{Context: r.ctx}
+	results := new(Results)
+	shouldPass := r.fnRunner.Run(fnCtx, rl.FunctionConfig, rl.Items, results)
+	// If running in a pipeline, the ResourceList may already have results from previous function runs.
+	// Thus, we only append new results to the end.
+	rl.Results = append(rl.Results, *results...)
+	return shouldPass, nil
+}
+
+func (r *runnerProcessor) config(o *KubeObject) error {
+	if r.fnRunner == nil {
+		return fmt.Errorf("the object which implements `ResourceListProcessor` interface requires a `Runner` or `fnRunner` attribute," +
+			" got nil")
+	}
+	switch o.GroupKind() {
+	case schema.GroupKind{Kind: "ConfigMap"}:
+		data, found, err := o.NestedStringMap("data")
+		if !found || err != nil {
+			return err
+		}
+		return assignCMDataToFn(r.fnRunner, data)
+	case schema.GroupKind{Group: KptFunctionGroup, Kind: asFnName(r.fnRunner)}:
+		return o.As(r.fnRunner)
+	default:
+		return fmt.Errorf("unknown FunctionConfig `%v`, expect `%v.%v` or `ConfigMap.v1`", o.GroupKind(), asFnName(r.fnRunner), KptFunctionGroup)
+	}
+}
+
+func asFnName(runner Runner) string {
+	// Validate the fnRunner type to avoid panic.
+	kind := reflect.ValueOf(runner).Kind()
+	if kind !=  reflect.Interface && kind != reflect.Ptr {
+		return ""
+	}
+	return reflect.ValueOf(runner).Elem().Type().Name()
+}
+
+func assignCMDataToFn(runner Runner, data map[string]string) error {
+	obj := reflect.ValueOf(runner).Elem()
+	if obj.Kind() != reflect.Struct{
+		return fmt.Errorf("the ConfigMap is not of a struct, got %v", obj.Kind().String())
+	}
+	stringMap := reflect.MapOf(reflect.TypeOf("string"), reflect.TypeOf("string"))
+	for i := 0; i < obj.NumField(); i++ {
+		if obj.Field(i).Kind() == reflect.Map && obj.Field(i).Type() == stringMap {
+			if obj.Field(i).CanSet() {
+				obj.Field(i).Set(reflect.ValueOf(data))
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("unable to assign the given ConfigMap `.data` to FunctionConfig %v. please make sure the %v " +
+		"has a field of type map[string]string", asFnName(runner), asFnName(runner))
 }

--- a/go/fn/runnerprocessor_test.go
+++ b/go/fn/runnerprocessor_test.go
@@ -1,0 +1,197 @@
+package fn
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var _ Runner = &SetTest{}
+
+type SetTestWithArgs interface {
+	GetArgs() string
+}
+
+type SetTest struct {
+	Arg map[string]string
+}
+
+func (*SetTest) Run(*Context, *KubeObject, KubeObjects,*Results) bool {
+	return true
+}
+
+func (s *SetTest) GetArgs() string {
+	return fmt.Sprintf("%v", s.Arg)
+}
+
+
+type SetTestNoMapString struct {
+	Arg string `yaml:"args" json:"args"`
+}
+
+func (*SetTestNoMapString) Run(*Context, *KubeObject, KubeObjects,*Results) bool {
+	return true
+}
+
+func (s *SetTestNoMapString) GetArgs() string {
+	return s.Arg
+}
+
+func TestProcess(t *testing.T) {
+	testdata := map[string]struct{
+		resourceList []byte
+		expectedOk bool
+		expectedErr string
+	}{
+		"functionConfig is empty": {
+			resourceList: []byte(`
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+functionConfig: {}
+`),
+			expectedOk: true,
+			expectedErr: "[info]: `FunctionConfig` is not given",
+		},
+		"functionConfig is create by kpt but actually is empty": {
+			resourceList: []byte(`
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+functionConfig: 
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: function-input
+  data: {}
+`),
+			expectedOk: true,
+			expectedErr: "[info]: `FunctionConfig` is not given",
+		},
+		"functionConfig error": {
+			resourceList: []byte(`
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+functionConfig: 
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: function-input
+  data: wrong-type
+`),
+			expectedOk: false,
+			expectedErr: "[error]: Resource(apiVersion=, kind=ConfigMap) has unmatched field type \"map[string]string\" in fieldpath .data",
+		},
+		"functionConfig pass": {
+			resourceList: []byte(`
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+functionConfig: 
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: function-input
+  data: 
+    k1: v1
+    k2: v2
+`),
+			expectedOk: true,
+			expectedErr: "",
+		},
+
+	}
+	for description, test := range testdata {
+		fnConfig := &SetTest{}
+		r := runnerProcessor{ctx: context.TODO(), fnRunner: fnConfig}
+		rl, _ := ParseResourceList(test.resourceList)
+		actualOk, _ := r.Process(rl)
+		assert.Equal(t, actualOk,  test.expectedOk, description)
+		assert.Equal(t, test.expectedErr, rl.Results.String(), description)
+	}
+}
+
+func TestRunnerConfig(t *testing.T) {
+	testdata := map[string]struct{
+		fnConfig []byte
+		expectedErr  string
+		expectedArgsToString string
+		runner SetTestWithArgs
+	}{
+		"functionConfig is ConfigMap, invalid data": {
+			fnConfig: []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data: wrong-type
+`),
+			runner: &SetTest{},
+			expectedErr: "Resource(apiVersion=, kind=ConfigMap) has unmatched field type \"map[string]string\" in fieldpath .data",
+		},
+		"functionConfig is ConfigMap, value assigned to Runner arg": {
+			fnConfig: []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data: 
+    k1: v1
+    k2: v2
+`),
+			runner: &SetTest{},
+			expectedErr: "",
+			expectedArgsToString: fmt.Sprintf("%v", map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+			}),
+		},
+		"functionConfig is ConfigMap, Runner does not have available arg to assign data": {
+			fnConfig: []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data: 
+    k1: v1
+    k2: v2
+`),
+			runner: &SetTestNoMapString{},
+			expectedErr: "unable to assign the given ConfigMap `.data` to FunctionConfig SetTestNoMapString. " +
+				"please make sure the SetTestNoMapString has a field of type map[string]string",
+			expectedArgsToString: "",
+		},
+		"functionConfig is custom kind, validate the GVK ": {
+			fnConfig: []byte(`
+apiVersion: badgroup/v1alpha1
+kind: SetTestNoMapString
+metadata:
+  name: test
+`),
+			runner: &SetTestNoMapString{},
+			expectedErr: "unknown FunctionConfig `SetTestNoMapString.badgroup`, expect `SetTestNoMapString.fn.kpt.dev` or `ConfigMap.v1`",
+			expectedArgsToString: "",
+		},
+		"functionConfig is custom kind, assign the value to runner": {
+			fnConfig: []byte(`
+apiVersion: fn.kpt.dev/v1alpha1
+kind: SetTestNoMapString
+metadata:
+  name: test
+args: test
+`),
+			runner: &SetTestNoMapString{},
+			expectedErr: "",
+			expectedArgsToString: "test",
+		},
+	}
+	for description, test := range testdata {
+		r := runnerProcessor{ctx: context.TODO(), fnRunner: test.runner.(Runner)}
+		fn, _ := ParseKubeObject(test.fnConfig)
+		actualErr := r.config(fn)
+		if test.expectedErr != "" {
+			assert.EqualError(t, actualErr, test.expectedErr, description)
+		} else {
+			assert.Equal(t, test.expectedArgsToString, test.runner.GetArgs(), description)
+		}
+	}
+}


### PR DESCRIPTION
Some major changes

- This PR better handles the `reflect` based operations:
   -  avoid panic if non pointer object is used
   - Specifically requires a `map[string]string` argument from the `Runner` object, and assigns the `ConfigMap.data` to it. Previously, it assigns the `ConfigMap.data` to the first struct type object, which could be problematic.
   - Check whether a field can be set before assigning the value.
- This PR handles a risk condition where users do not provide the a `FunctionConfig` object but kpt creates a placeholder and adds it to ResourceList, previously we could not tell whether the FunctionConfig is from users or kpt and thus cannot guide users helpful information on whether a fnConfig is missing or misconfigured. This PR adds a check specifically for the kpt generated FunctionConfig, and give users more actionable message. In the SDK, empty functionConfig is treated as valid (Info severity result) and the actual empty fnConfig validation should be on the client (KRM function) side (whether empty fnConfig is acceptable or not). 
- Add user messages with actionable suggestions to each error.  
- add full unit test coverage