### PR TITLE
Update ci to validate gofmt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,9 +75,7 @@ jobs:
       with:
         path: go/src/github.com/GoogleContainerTools/kpt-functions-sdk
     - name: Build, Test, Lint
-      run: |
-        cd go
-        make all
+      run: hack/ci-validate-go.sh
     - name: Test typegen
       run: |
         cd ts/typegen

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: go
+go: ## Run all e2e tests
+	cd go && $(MAKE) all

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,11 +1,10 @@
-.PHONY: api fix vet fmt test lint license
+.PHONY: all
+all: fix vet fmt test lint license
 
 GOPATH := $(shell go env GOPATH)
 GOBIN := $(shell go env GOPATH)/bin
 OUT_DIR := .out
 MODULES = $(shell find . -name 'go.mod' -print)
-
-all: fix fmt license lint test
 
 .PHONY: api
 api:
@@ -18,7 +17,7 @@ fix: $(MODULES)
 
 .PHONY: fmt
 fmt: $(MODULES)
-	@for f in $(^D); do (cd $$f; echo "Formatting $$f"; gofmt -s -w .); done
+	@for f in $(^D); do (cd $$f; echo "Formatting $$f"; go fmt ./...); done
 
 .PHONY: lint
 lint: $(MODULES)

--- a/go/fn/examples/data/setlabels-resourcelist.yaml
+++ b/go/fn/examples/data/setlabels-resourcelist.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: config.kubernetes.io/v1
 kind: ResourceList
 items:

--- a/go/fn/examples/example_select_exclude_test.go
+++ b/go/fn/examples/example_select_exclude_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package example
 
 import (

--- a/go/fn/internal/namespace.go
+++ b/go/fn/internal/namespace.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import (

--- a/go/fn/object_test.go
+++ b/go/fn/object_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fn
 
 import (

--- a/go/fn/resourcelist_test.go
+++ b/go/fn/resourcelist_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fn
 
 import (

--- a/go/fn/runnerprocessor_test.go
+++ b/go/fn/runnerprocessor_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fn
 
 import (
@@ -18,7 +32,7 @@ type SetTest struct {
 	Arg map[string]string
 }
 
-func (*SetTest) Run(*Context, *KubeObject, KubeObjects,*Results) bool {
+func (*SetTest) Run(*Context, *KubeObject, KubeObjects, *Results) bool {
 	return true
 }
 
@@ -26,12 +40,11 @@ func (s *SetTest) GetArgs() string {
 	return fmt.Sprintf("%v", s.Arg)
 }
 
-
 type SetTestNoMapString struct {
 	Arg string `yaml:"args" json:"args"`
 }
 
-func (*SetTestNoMapString) Run(*Context, *KubeObject, KubeObjects,*Results) bool {
+func (*SetTestNoMapString) Run(*Context, *KubeObject, KubeObjects, *Results) bool {
 	return true
 }
 
@@ -40,10 +53,10 @@ func (s *SetTestNoMapString) GetArgs() string {
 }
 
 func TestProcess(t *testing.T) {
-	testdata := map[string]struct{
+	testdata := map[string]struct {
 		resourceList []byte
-		expectedOk bool
-		expectedErr string
+		expectedOk   bool
+		expectedErr  string
 	}{
 		"functionConfig is empty": {
 			resourceList: []byte(`
@@ -51,7 +64,7 @@ apiVersion: config.kubernetes.io/v1
 kind: ResourceList
 functionConfig: {}
 `),
-			expectedOk: true,
+			expectedOk:  true,
 			expectedErr: "[info]: `FunctionConfig` is not given",
 		},
 		"functionConfig is create by kpt but actually is empty": {
@@ -65,7 +78,7 @@ functionConfig:
     name: function-input
   data: {}
 `),
-			expectedOk: true,
+			expectedOk:  true,
 			expectedErr: "[info]: `FunctionConfig` is not given",
 		},
 		"functionConfig error": {
@@ -79,7 +92,7 @@ functionConfig:
     name: function-input
   data: wrong-type
 `),
-			expectedOk: false,
+			expectedOk:  false,
 			expectedErr: "[error]: Resource(apiVersion=, kind=ConfigMap) has unmatched field type \"map[string]string\" in fieldpath .data",
 		},
 		"functionConfig pass": {
@@ -95,27 +108,26 @@ functionConfig:
     k1: v1
     k2: v2
 `),
-			expectedOk: true,
+			expectedOk:  true,
 			expectedErr: "",
 		},
-
 	}
 	for description, test := range testdata {
 		fnConfig := &SetTest{}
 		r := runnerProcessor{ctx: context.TODO(), fnRunner: fnConfig}
 		rl, _ := ParseResourceList(test.resourceList)
 		actualOk, _ := r.Process(rl)
-		assert.Equal(t, actualOk,  test.expectedOk, description)
+		assert.Equal(t, actualOk, test.expectedOk, description)
 		assert.Equal(t, test.expectedErr, rl.Results.String(), description)
 	}
 }
 
 func TestRunnerConfig(t *testing.T) {
-	testdata := map[string]struct{
-		fnConfig []byte
-		expectedErr  string
+	testdata := map[string]struct {
+		fnConfig             []byte
+		expectedErr          string
 		expectedArgsToString string
-		runner SetTestWithArgs
+		runner               SetTestWithArgs
 	}{
 		"functionConfig is ConfigMap, invalid data": {
 			fnConfig: []byte(`
@@ -125,7 +137,7 @@ metadata:
   name: test
 data: wrong-type
 `),
-			runner: &SetTest{},
+			runner:      &SetTest{},
 			expectedErr: "Resource(apiVersion=, kind=ConfigMap) has unmatched field type \"map[string]string\" in fieldpath .data",
 		},
 		"functionConfig is ConfigMap, value assigned to Runner arg": {
@@ -138,7 +150,7 @@ data:
     k1: v1
     k2: v2
 `),
-			runner: &SetTest{},
+			runner:      &SetTest{},
 			expectedErr: "",
 			expectedArgsToString: fmt.Sprintf("%v", map[string]string{
 				"k1": "v1",
@@ -167,8 +179,8 @@ kind: SetTestNoMapString
 metadata:
   name: test
 `),
-			runner: &SetTestNoMapString{},
-			expectedErr: "unknown FunctionConfig `SetTestNoMapString.badgroup`, expect `SetTestNoMapString.fn.kpt.dev` or `ConfigMap.v1`",
+			runner:               &SetTestNoMapString{},
+			expectedErr:          "unknown FunctionConfig `SetTestNoMapString.badgroup`, expect `SetTestNoMapString.fn.kpt.dev` or `ConfigMap.v1`",
 			expectedArgsToString: "",
 		},
 		"functionConfig is custom kind, assign the value to runner": {
@@ -179,8 +191,8 @@ metadata:
   name: test
 args: test
 `),
-			runner: &SetTestNoMapString{},
-			expectedErr: "",
+			runner:               &SetTestNoMapString{},
+			expectedErr:          "",
 			expectedArgsToString: "test",
 		},
 	}

--- a/go/fn/testhelpers/golden.go
+++ b/go/fn/testhelpers/golden.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testhelpers
 
 import (
@@ -15,17 +29,19 @@ import (
 )
 
 // RunGoldenTests provides the test infra to run golden test.
-// - "basedir" should be the parent directory, under where the sub-directories contains test data.
-//   For example, the "testdata" is the basedir. It contains two cases "test1" and "test2"
-//   └── testdata
-//       └── test1
-//           ├── _expected.yaml
-//           ├── _fnconfig.yaml
-//           └── resources.yaml
-//       └── test2
-//           ├── _expected.yaml
-//           ├── _fnconfig.yaml
-//           └── resources.yaml
+// "basedir" should be the parent directory, under where the sub-directories contains test data.
+// For example, the "testdata" is the basedir. It contains two cases "test1" and "test2"
+//
+//	└── testdata
+//	    └── test1
+//	        ├── _expected.yaml
+//	        ├── _fnconfig.yaml
+//	        └── resources.yaml
+//	    └── test2
+//	        ├── _expected.yaml
+//	        ├── _fnconfig.yaml
+//	        └── resources.yaml
+//
 // - "krmFunction" should be your ResourceListProcessor implementation.
 func RunGoldenTests(t *testing.T, basedir string, krmFunction fn.ResourceListProcessor) {
 	dirEntries, err := os.ReadDir(basedir)

--- a/go/get-started/data/resources.yaml
+++ b/go/get-started/data/resources.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/go/get-started/main.go
+++ b/go/get-started/main.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/hack/ci-validate-go.sh
+++ b/hack/ci-validate-go.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,14 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -o errexit
+set -o nounset
+set -o pipefail
 
-FROM golang:1.17-alpine3.15
-ENV CGO_ENABLED=0
-WORKDIR /go/src/
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-RUN go build -o /usr/local/bin/function ./
-FROM alpine:3.15
-COPY --from=0 /usr/local/bin/function /usr/local/bin/function
-ENTRYPOINT ["function"]
+make go
+
+changes=$(git status --porcelain)
+if [ -n "${changes}" ]; then
+  echo "ERROR: files are not to date; please run: hack/generate.sh"
+  echo "changed files:"
+  printf "%s" "${changes}\n"
+  echo "git diff:"
+  git --no-pager diff
+  exit 1
+fi


### PR DESCRIPTION
Problem: Previous CI checks the license and gofmt but does not raise the error to users  (it just outputs the files as unstaged and then abandoned them). 

This PR does 3 fixes
- Added the missing CopyRight
- Fixed the go fmt
- Added a generate.sh which checks the license and gofmt are all commited; Update the CI to rely on the generate.sh to pass/fail the check.    