### PR TITLE
Fix naming collisions in generated typescript with two arrays in same object

### DIFF
--- a/ts/typegen/cmd/main.go
+++ b/ts/typegen/cmd/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -42,7 +41,7 @@ var mainCmd = &cobra.Command{
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		swaggerPath := args[0]
-		bytes, err := ioutil.ReadFile(swaggerPath)
+		bytes, err := os.ReadFile(swaggerPath)
 		if err != nil {
 			return errors.Wrap(err, "unable to find Swagger file")
 		}
@@ -90,7 +89,7 @@ func printTS(outPath string, refObjects map[swagger.Ref]swagger.Object, definiti
 			contents = append(contents, lang.PrintDefinition(definition))
 		}
 
-		err := ioutil.WriteFile(filepath.Join(outPath, pkg+".ts"), []byte(strings.Join(contents, "\n\n")), 0644)
+		err := os.WriteFile(filepath.Join(outPath, pkg+".ts"), []byte(strings.Join(contents, "\n\n")), 0644)
 		if err != nil {
 			return err
 		}

--- a/ts/typegen/swagger/arrays.go
+++ b/ts/typegen/swagger/arrays.go
@@ -39,12 +39,24 @@ func (a Array) NestedTypes() []Object {
 	return a.Nested
 }
 
+func isArray(m map[string]interface{}) bool {
+	typ, found := getString("type", m)
+	if !found {
+		return false
+	}
+	return typ == ARRAY
+}
+
 func (p parser) parseArray(definitionMeta DefinitionMeta, o map[string]interface{}) Array {
+	return p.parseArrayWithName(definitionMeta, "Item", o)
+}
+
+func (p parser) parseArrayWithName(definitionMeta DefinitionMeta, name string, o map[string]interface{}) Array {
 	itemsMap := getRequiredMap("items", o)
 	if isObject(itemsMap) {
 		description, _ := getString("description", itemsMap)
 		meta := DefinitionMeta{
-			Name:        "Item",
+			Name:        name,
 			Package:     definitionMeta.Package,
 			Namespace:   append(definitionMeta.Namespace, definitionMeta.Name),
 			Description: description,
@@ -53,7 +65,7 @@ func (p parser) parseArray(definitionMeta DefinitionMeta, o map[string]interface
 		return Array{
 			Items: Ref{
 				Package: definitionMeta.Package,
-				Name:    strings.Join(append(meta.Namespace, "Item"), "."),
+				Name:    strings.Join(append(meta.Namespace, name), "."),
 			},
 			Nested: []Object{object},
 		}

--- a/ts/typegen/swagger/language/languages.go
+++ b/ts/typegen/swagger/language/languages.go
@@ -21,7 +21,6 @@ import "github.com/GoogleContainerTools/kpt-functions-sdk/ts/typegen/swagger"
 // Implementors of Language must satisfy the following properties:
 //
 // 1) The order Definitions are printed in a file MUST have no impact on whether code compiles/works.
-//
 type Language interface {
 	// File returns the relative path to definition's client code.
 	File(definition swagger.Definition) string

--- a/ts/typegen/swagger/properties.go
+++ b/ts/typegen/swagger/properties.go
@@ -15,6 +15,7 @@
 package swagger
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -77,6 +78,9 @@ func (p parser) parseProperties(definitionMeta DefinitionMeta, model map[string]
 				Name:    strings.Join(append(propertyDefinitionMeta.Namespace, propertyType), "."),
 				Package: definitionMeta.Package,
 			}
+		} else if isArray(propertyMap) {
+			name := fmt.Sprintf("%sItem", strings.Title(name)) //nolint:staticcheck
+			typ = p.parseArrayWithName(definitionMeta, name, propertyMap)
 		} else {
 			typ = p.parseType(definitionMeta, propertyMap)
 		}

--- a/ts/typegen/swagger/swagger_test.go
+++ b/ts/typegen/swagger/swagger_test.go
@@ -16,30 +16,32 @@ package swagger
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func TestSwagger(t *testing.T) {
 	// Ensures real Swagger definitions are actually parseable. Will be updated as type generation is made more
 	// sophisticated.
-	testCases := []struct {
+	testCases := map[string]struct {
 		name string
 		path string
 	}{
-		{
-			name: "1.13.0",
+		"k8s 1.13.0": {
 			path: "testdata/swagger-v1.13.0.json",
 		},
-		{
-			name: "1.14.3",
+		"k8s 1.14.3": {
 			path: "testdata/swagger-v1.14.3.json",
+		},
+		"two arrays in the same spec": {
+			path: "testdata/two-arrays-swagger.json",
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			bytes, err := ioutil.ReadFile(tc.path)
+	for tn := range testCases {
+		tc := testCases[tn]
+		t.Run(tn, func(t *testing.T) {
+			bytes, err := os.ReadFile(tc.path)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/ts/typegen/swagger/testdata/two-arrays-swagger.json
+++ b/ts/typegen/swagger/testdata/two-arrays-swagger.json
@@ -1,0 +1,1410 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Kubernetes",
+        "version": "v1.24.0"
+    },
+
+    "definitions": {
+        "domain.my.webapp.v1.Guestbook": {
+            "description": "Guestbook is the Schema for the guestbooks API",
+            "type": "object",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+                },
+                "spec": {
+                    "description": "GuestbookSpec defines the desired state of Guestbook",
+                    "type": "object",
+                    "properties": {
+                        "foo": {
+                            "description": "Foo is an example field of Guestbook. Edit guestbook_types.go to remove/update",
+                            "type": "string"
+                        },
+                        "inputs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "outputs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "status": {
+                    "description": "GuestbookStatus defines the observed state of Guestbook",
+                    "type": "object"
+                }
+            },
+            "x-kubernetes-group-version-kind": [
+                {
+                    "group": "webapp.my.domain",
+                    "kind": "Guestbook",
+                    "version": "v1"
+                }
+            ]
+        },
+        "domain.my.webapp.v1.GuestbookList": {
+            "description": "GuestbookList is a list of Guestbook",
+            "required": [
+                "items"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "List of guestbooks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.my.webapp.v1.Guestbook"
+                    }
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+                }
+            },
+            "x-kubernetes-group-version-kind": [
+                {
+                    "group": "webapp.my.domain",
+                    "kind": "GuestbookList",
+                    "version": "v1"
+                }
+            ]
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.APIVersions": {
+            "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
+            "type": "object",
+            "required": [
+                "versions",
+                "serverAddressByClientCIDRs"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "serverAddressByClientCIDRs": {
+                    "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
+                    }
+                },
+                "versions": {
+                    "description": "versions are the api versions that are available.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "x-kubernetes-group-version-kind": [
+                {
+                    "group": "",
+                    "kind": "APIVersions",
+                    "version": "v1"
+                }
+            ]
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "type": "object",
+            "required": [
+                "type",
+                "status",
+                "lastTransitionTime",
+                "reason",
+                "message"
+            ],
+            "properties": {
+                "lastTransitionTime": {
+                    "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                },
+                "message": {
+                    "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                    "type": "string"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "reason": {
+                    "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "status of the condition, one of True, False, Unknown.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+            "description": "DeleteOptions may be provided when deleting an API object.",
+            "type": "object",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "dryRun": {
+                    "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "gracePeriodSeconds": {
+                    "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "orphanDependents": {
+                    "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+                    "type": "boolean"
+                },
+                "preconditions": {
+                    "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+                },
+                "propagationPolicy": {
+                    "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+                    "type": "string"
+                }
+            },
+            "x-kubernetes-group-version-kind": [
+                {
+                    "group": "",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "admission.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "admission.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "admissionregistration.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "admissionregistration.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "apiextensions.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "apiextensions.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "apiregistration.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "apiregistration.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "apps",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "apps",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "apps",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta2"
+                },
+                {
+                    "group": "authentication.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "authentication.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "authorization.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "authorization.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "autoscaling",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "autoscaling",
+                    "kind": "DeleteOptions",
+                    "version": "v2"
+                },
+                {
+                    "group": "autoscaling",
+                    "kind": "DeleteOptions",
+                    "version": "v2beta1"
+                },
+                {
+                    "group": "autoscaling",
+                    "kind": "DeleteOptions",
+                    "version": "v2beta2"
+                },
+                {
+                    "group": "batch",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "batch",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "certificates.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "certificates.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "coordination.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "coordination.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "discovery.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "discovery.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "events.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "events.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "extensions",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "flowcontrol.apiserver.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "flowcontrol.apiserver.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "flowcontrol.apiserver.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta2"
+                },
+                {
+                    "group": "imagepolicy.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "internal.apiserver.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "networking.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "networking.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "node.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "node.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "node.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "policy",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "policy",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "rbac.authorization.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "rbac.authorization.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "rbac.authorization.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "scheduling.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "scheduling.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "scheduling.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "storage.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1"
+                },
+                {
+                    "group": "storage.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "storage.k8s.io",
+                    "kind": "DeleteOptions",
+                    "version": "v1beta1"
+                }
+            ]
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions_v2": {
+            "description": "DeleteOptions may be provided when deleting an API object.",
+            "type": "object",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "dryRun": {
+                    "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "gracePeriodSeconds": {
+                    "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "orphanDependents": {
+                    "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+                    "type": "boolean"
+                },
+                "preconditions": {
+                    "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+                },
+                "propagationPolicy": {
+                    "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+            "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+            "type": "object"
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
+            "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+            "type": "object",
+            "required": [
+                "groupVersion",
+                "version"
+            ],
+            "properties": {
+                "groupVersion": {
+                    "description": "groupVersion specifies the API group and version in the form \"group/version\"",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+            "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "type": "object",
+            "properties": {
+                "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+                    }
+                },
+                "matchLabels": {
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "x-kubernetes-map-type": "atomic"
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+            "type": "object",
+            "required": [
+                "key",
+                "operator"
+            ],
+            "properties": {
+                "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string",
+                    "x-kubernetes-patch-merge-key": "key",
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                },
+                "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+            "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+            "type": "object",
+            "properties": {
+                "continue": {
+                    "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+                    "type": "string"
+                },
+                "remainingItemCount": {
+                    "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "resourceVersion": {
+                    "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "selfLink": {
+                    "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+            "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+            "type": "object",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                    "type": "string"
+                },
+                "fieldsType": {
+                    "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                    "type": "string"
+                },
+                "fieldsV1": {
+                    "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+                },
+                "manager": {
+                    "description": "Manager is an identifier of the workflow managing these fields.",
+                    "type": "string"
+                },
+                "operation": {
+                    "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                    "type": "string"
+                },
+                "subresource": {
+                    "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                    "type": "string"
+                },
+                "time": {
+                    "description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+            "description": "MicroTime is version of Time with microsecond level precision.",
+            "type": "string",
+            "format": "date-time"
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+            "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "clusterName": {
+                    "description": "Deprecated: ClusterName is a legacy field that was always cleared by the system and never used; it will be removed completely in 1.25.\n\nThe name in the go struct is changed to help clients detect accidental use.",
+                    "type": "string"
+                },
+                "creationTimestamp": {
+                    "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                },
+                "deletionGracePeriodSeconds": {
+                    "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "deletionTimestamp": {
+                    "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                },
+                "finalizers": {
+                    "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "generateName": {
+                    "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                    "type": "string"
+                },
+                "generation": {
+                    "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "labels": {
+                    "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "managedFields": {
+                    "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+                    }
+                },
+                "name": {
+                    "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                    "type": "string"
+                },
+                "ownerReferences": {
+                    "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+                    },
+                    "x-kubernetes-patch-merge-key": "uid",
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "resourceVersion": {
+                    "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "selfLink": {
+                    "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2": {
+            "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "clusterName": {
+                    "description": "Deprecated: ClusterName is a legacy field that was always cleared by the system and never used; it will be removed completely in 1.25.\n\nThe name in the go struct is changed to help clients detect accidental use.",
+                    "type": "string"
+                },
+                "creationTimestamp": {
+                    "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                },
+                "deletionGracePeriodSeconds": {
+                    "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "deletionTimestamp": {
+                    "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                },
+                "finalizers": {
+                    "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "generateName": {
+                    "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                    "type": "string"
+                },
+                "generation": {
+                    "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "labels": {
+                    "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "managedFields": {
+                    "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+                    }
+                },
+                "name": {
+                    "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                    "type": "string"
+                },
+                "ownerReferences": {
+                    "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference_v2"
+                    },
+                    "x-kubernetes-patch-merge-key": "uid",
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "resourceVersion": {
+                    "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "selfLink": {
+                    "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "name",
+                "uid"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                },
+                "blockOwnerDeletion": {
+                    "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                    "type": "boolean"
+                },
+                "controller": {
+                    "description": "If true, this reference points to the managing controller.",
+                    "type": "boolean"
+                },
+                "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                    "type": "string"
+                }
+            },
+            "x-kubernetes-map-type": "atomic"
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference_v2": {
+            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+            "type": "object",
+            "required": [
+                "apiVersion",
+                "kind",
+                "name",
+                "uid"
+            ],
+            "properties": {
+                "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                },
+                "blockOwnerDeletion": {
+                    "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                    "type": "boolean"
+                },
+                "controller": {
+                    "description": "If true, this reference points to the managing controller.",
+                    "type": "boolean"
+                },
+                "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                    "type": "string"
+                }
+            },
+            "x-kubernetes-map-type": "atomic"
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+            "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+            "type": "object"
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+            "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+            "type": "object",
+            "properties": {
+                "resourceVersion": {
+                    "description": "Specifies the target ResourceVersion",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "Specifies the target UID.",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
+            "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+            "type": "object",
+            "required": [
+                "clientCIDR",
+                "serverAddress"
+            ],
+            "properties": {
+                "clientCIDR": {
+                    "description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+                    "type": "string"
+                },
+                "serverAddress": {
+                    "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+            "description": "Status is a return value for calls that don't return other objects.",
+            "type": "object",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "code": {
+                    "description": "Suggested HTTP return code for this status, 0 if not set.",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "details": {
+                    "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "A human-readable description of the status of this operation.",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+                },
+                "reason": {
+                    "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                    "type": "string"
+                }
+            },
+            "x-kubernetes-group-version-kind": [
+                {
+                    "group": "",
+                    "kind": "Status",
+                    "version": "v1"
+                }
+            ]
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+            "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+            "type": "object",
+            "properties": {
+                "field": {
+                    "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+                    "type": "string"
+                },
+                "reason": {
+                    "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+            "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+            "type": "object",
+            "properties": {
+                "causes": {
+                    "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+                    }
+                },
+                "group": {
+                    "description": "The group attribute of the resource associated with the status StatusReason.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+                    "type": "string"
+                },
+                "retryAfterSeconds": {
+                    "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "uid": {
+                    "description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails_v2": {
+            "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+            "type": "object",
+            "properties": {
+                "causes": {
+                    "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+                    }
+                },
+                "group": {
+                    "description": "The group attribute of the resource associated with the status StatusReason.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+                    "type": "string"
+                },
+                "retryAfterSeconds": {
+                    "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "uid": {
+                    "description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.Status_v2": {
+            "description": "Status is a return value for calls that don't return other objects.",
+            "type": "object",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "code": {
+                    "description": "Suggested HTTP return code for this status, 0 if not set.",
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "details": {
+                    "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails_v2"
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "A human-readable description of the status of this operation.",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+                },
+                "reason": {
+                    "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                    "type": "string"
+                }
+            }
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+            "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+            "type": "string",
+            "format": "date-time"
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+            "description": "Event represents a single event to a watched resource.",
+            "type": "object",
+            "required": [
+                "type",
+                "object"
+            ],
+            "properties": {
+                "object": {
+                    "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "x-kubernetes-group-version-kind": [
+                {
+                    "group": "",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "admission.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "admission.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "admissionregistration.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "admissionregistration.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "apiextensions.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "apiextensions.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "apiregistration.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "apiregistration.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "apps",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "apps",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "apps",
+                    "kind": "WatchEvent",
+                    "version": "v1beta2"
+                },
+                {
+                    "group": "authentication.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "authentication.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "authorization.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "authorization.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "autoscaling",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "autoscaling",
+                    "kind": "WatchEvent",
+                    "version": "v2"
+                },
+                {
+                    "group": "autoscaling",
+                    "kind": "WatchEvent",
+                    "version": "v2beta1"
+                },
+                {
+                    "group": "autoscaling",
+                    "kind": "WatchEvent",
+                    "version": "v2beta2"
+                },
+                {
+                    "group": "batch",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "batch",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "certificates.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "certificates.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "coordination.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "coordination.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "discovery.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "discovery.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "events.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "events.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "extensions",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "flowcontrol.apiserver.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "flowcontrol.apiserver.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "flowcontrol.apiserver.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta2"
+                },
+                {
+                    "group": "imagepolicy.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "internal.apiserver.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "networking.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "networking.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "node.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "node.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "node.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "policy",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "policy",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "rbac.authorization.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "rbac.authorization.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "rbac.authorization.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "scheduling.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "scheduling.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "scheduling.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                },
+                {
+                    "group": "storage.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1"
+                },
+                {
+                    "group": "storage.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1alpha1"
+                },
+                {
+                    "group": "storage.k8s.io",
+                    "kind": "WatchEvent",
+                    "version": "v1beta1"
+                }
+            ]
+        }
+    },
+    "securityDefinitions": {
+        "BearerToken": {
+            "description": "Bearer Token authentication",
+            "type": "apiKey",
+            "name": "authorization",
+            "in": "header"
+        }
+    },
+    "security": [
+        {
+            "BearerToken": []
+        }
+    ]
+}


### PR DESCRIPTION
This fixes an issue where the name of the Typescript type for an array entry always ended up being named `Item`. This causes problem when an object in the swagger document has more then one field with type array.

It also fixes some linter issues.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/3686