### PR TITLE
Update workflow for releasing typegen

### DIFF
--- a/.github/workflows/release-typegen.yaml
+++ b/.github/workflows/release-typegen.yaml
@@ -8,19 +8,14 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      GOPATH: /home/runner/work/kpt-functions-sdk/ts/typegen
-      GO111MODULE: on
     steps:
-      - name: Set up Go 1.17
-        uses: actions/setup-go@v1
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
         id: go
-      - name: Check out code into GOPATH
-        uses: actions/checkout@v1
-        with:
-          path: go/src/github.com/GoogleContainerTools/kpt-functions-sdk
+      - name: Check out code
+        uses: actions/checkout@v3
       - name: Build, Test, Lint
         run: |
           cd ts/typegen


### PR DESCRIPTION
Update the typegen release workflow to use the latest versions of the actions and also use go 1.19.