### PR TITLE
Fix bins upload script to reference the correct path

### DIFF
--- a/ts/scripts/publish-bins.sh
+++ b/ts/scripts/publish-bins.sh
@@ -20,5 +20,5 @@ set -xeuo pipefail
 
 VERSION=${1#*-v};
 
-cd go/.out
+cd ts/typegen/.out
 gsutil cp -- *.tar.gz gs://kpt-functions/v"${VERSION}"


### PR DESCRIPTION
I think the repo was reorganized at some point and this updates the script to point to the new paths for the typegen artifacts.