### PR TITLE
Handle empty input gracefully

### DIFF
--- a/go/fn/object.go
+++ b/go/fn/object.go
@@ -730,7 +730,7 @@ func IsMetaResource() func(*KubeObject) bool {
 }
 
 func (o *KubeObject) IsEmpty() bool {
-	return yaml.IsYNodeEmptyMap(o.obj.Node())
+	return o == nil || o.obj == nil || yaml.IsYNodeEmptyMap(o.obj.Node())
 }
 
 func NewEmptyKubeObject() *KubeObject {

--- a/go/fn/resourcelist.go
+++ b/go/fn/resourcelist.go
@@ -94,6 +94,9 @@ func ParseResourceList(in []byte) (*ResourceList, error) {
 
 	// handle empty input
 	if len(bytes.TrimSpace(in)) == 0 {
+		rl.Items = make(KubeObjects, 0)
+		rl.Results = make(Results, 0)
+		rl.FunctionConfig = NewEmptyKubeObject()
 		return rl, nil
 	}
 

--- a/go/fn/resourcelist.go
+++ b/go/fn/resourcelist.go
@@ -16,6 +16,7 @@
 package fn
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"sort"
@@ -90,9 +91,15 @@ func CheckResourceDuplication(rl *ResourceList) error {
 // or KRM fn output
 func ParseResourceList(in []byte) (*ResourceList, error) {
 	rl := &ResourceList{}
+
+	// handle empty input
+	if len(bytes.TrimSpace(in)) == 0 {
+		return rl, nil
+	}
+
 	rlObj, err := ParseKubeObject(in)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse input bytes: %w", err)
+		return nil, fmt.Errorf("failed to parse ResourceList as a single KubeObject: %w", err)
 	}
 	if rlObj.GetKind() != kio.ResourceListKind {
 		return nil, fmt.Errorf("input was of unexpected kind %q; expected ResourceList", rlObj.GetKind())

--- a/go/fn/resourcelist.go
+++ b/go/fn/resourcelist.go
@@ -179,7 +179,7 @@ func (rl *ResourceList) toYNode() (*yaml.Node, error) {
 			return nil, err
 		}
 	}
-	if !rl.FunctionConfig.IsEmpty() {
+	if rl.FunctionConfig != nil && !rl.FunctionConfig.IsEmpty() {
 		if err := reMap.SetNestedMap(rl.FunctionConfig.node(), "functionConfig"); err != nil {
 			return nil, err
 		}

--- a/go/fn/resourcelist_test.go
+++ b/go/fn/resourcelist_test.go
@@ -15,9 +15,12 @@
 package fn
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
 var dupResourceInput = []byte(`
@@ -77,4 +80,25 @@ results:
 	if !cmp.Equal(expected, rl.Results) {
 		t.Fatalf("unexpected diff: %v", cmp.Diff(expected, rl.Results))
 	}
+}
+
+func TestParseZeroBytesResourceList(t *testing.T) {
+	rl, err := ParseResourceList([]byte{})
+	require.NoError(t, err)
+	require.NotNil(t, rl)
+}
+
+// This caused a panic before
+func TestEmptyToYAML(t *testing.T) {
+	rl := &ResourceList{}
+
+	var out []byte
+	var err error
+	require.NotPanics(t, func() {
+		out, err = rl.ToYAML()
+	})
+
+	require.NoError(t, err)
+	expected := fmt.Sprintf("apiVersion: %s\nkind: %s\n", kio.ResourceListAPIVersion, kio.ResourceListKind)
+	require.Equal(t, expected, string(out))
 }

--- a/go/fn/run_test.go
+++ b/go/fn/run_test.go
@@ -30,6 +30,6 @@ func TestRunEmptyInputBytes(t *testing.T) {
 
 	output, err := Run(noOpFn, []byte{})
 	require.NoError(t, err)
-	expected := []byte(fmt.Sprintf("apiVersion: %s\nkind: %s\n", kio.ResourceListAPIVersion, kio.ResourceListKind))
+	expected := fmt.Appendf(nil, "apiVersion: %s\nkind: %s\n", kio.ResourceListAPIVersion, kio.ResourceListKind)
 	assert.Equal(t, expected, output)
 }

--- a/go/fn/run_test.go
+++ b/go/fn/run_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+)
+
+func TestRunEmptyInputBytes(t *testing.T) {
+	var noOpFn ResourceListProcessorFunc = func(rl *ResourceList) (bool, error) {
+		return true, nil
+	}
+
+	output, err := Run(noOpFn, []byte{})
+	require.NoError(t, err)
+	expected := []byte(fmt.Sprintf("apiVersion: %s\nkind: %s\n", kio.ResourceListAPIVersion, kio.ResourceListKind))
+	assert.Equal(t, expected, output)
+}


### PR DESCRIPTION
Previously, running a ResourceListProcessor with the SDK and giving it a 0 length input resulted in a parsing error since we expected a KubeObject to be parsed from said input. This is now handled in this PR.

Added some extra unit tests for things I ran unto during debugging.