### PR TITLE
Fix dependency caching in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: CI
 
 on:
@@ -35,5 +49,6 @@ jobs:
       with:
         go-version-file: go/fn/go.mod
         install-kpt: 'false'
+        cache-dependency-path: go/**/go.sum
     - name: Build, Test, Lint
       run: hack/ci-validate-go.sh


### PR DESCRIPTION
Add license header and fix dependency caching in CI workflow

## Description
  - What changed: Added Apache 2.0 license header to `.github/workflows/ci.yaml` and added `cache-dependency-path` parameter to the `setup-go-kpt` action.
  - Why it's needed: The `cache-dependency-path` ensures Go module dependencies are properly cached across all Go
  modules (`go/*/go.sum`) in the repo.
  - How it works: The `cache-dependency-path` glob tells the setup action where to find go.sum files for cache key generation, improving CI build times.

 ## Type of Change
  - [ ] Bug fix
  - [ ] New feature
  - [x] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## AI Disclosure

  - [x] I have used Kiro CLI in the creation of this PR.