### PR TITLE
Allow implicit ResourceListProcessorFunc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,7 @@ GO_MOD_DIRS = $(shell find . -name 'go.mod' -exec sh -c 'echo \"$$(dirname "{}")
 .PHONY: tidy
 tidy:
 	@for f in $(GO_MOD_DIRS); do (cd $$f; echo "Tidying $$f"; go mod tidy) || exit 1; done
+
+.PHONY: test
+test:
+	make -C go test

--- a/go/Makefile
+++ b/go/Makefile
@@ -30,7 +30,7 @@ lint-modules: $(MODULES)
 
 .PHONY: test
 test: $(MODULES)
-	@for f in $(^D); do (cd $$f; echo "Testing $$f"; go test ./...) || exit 1; done
+	@for f in $(^D); do (cd $$f; echo "Testing $$f"; go test -v ./...) || exit 1; done
 
 .PHONY: vet
 vet: $(MODULES)

--- a/go/fn/run.go
+++ b/go/fn/run.go
@@ -86,12 +86,11 @@ func AsMain(input any, opts ...Option) error {
 
 	err := func() error {
 		var p ResourceListProcessor
-		switch input := input.(type) {
-		case runnerProcessor:
-			p = input
-		case ResourceListProcessorFunc:
-			p = input
-		default:
+		if cast, ok := input.(ResourceListProcessor); ok {
+			p = cast
+		} else if cast, ok := input.(func(*ResourceList) (bool, error)); ok {
+			p = ResourceListProcessorFunc(cast)
+		} else {
 			return fmt.Errorf("unknown input type %T", input)
 		}
 
@@ -208,14 +207,6 @@ func readFilesAsResourceList(paths []string) (*ResourceList, error) {
 // Run evaluates the function. input must be a resourceList in yaml format. An
 // updated resourceList will be returned.
 func Run(p ResourceListProcessor, input []byte) ([]byte, error) {
-	switch input := p.(type) {
-	case runnerProcessor:
-		p = input
-	case ResourceListProcessorFunc:
-		p = input
-	default:
-		return nil, fmt.Errorf("unknown input type %T", input)
-	}
 	rl, err := ParseResourceList(input)
 	if err != nil {
 		return nil, err

--- a/go/fn/run.go
+++ b/go/fn/run.go
@@ -208,6 +208,9 @@ func readFilesAsResourceList(paths []string) (*ResourceList, error) {
 // Run evaluates the function. input must be a resourceList in yaml format. An
 // updated resourceList will be returned.
 func Run(p ResourceListProcessor, input []byte) ([]byte, error) {
+	if p == nil {
+		return nil, fmt.Errorf("nil ResourceListProcessor")
+	}
 	rl, err := ParseResourceList(input)
 	if err != nil {
 		return nil, err

--- a/go/fn/run.go
+++ b/go/fn/run.go
@@ -86,11 +86,12 @@ func AsMain(input any, opts ...Option) error {
 
 	err := func() error {
 		var p ResourceListProcessor
-		if cast, ok := input.(ResourceListProcessor); ok {
+		switch cast := input.(type) {
+		case ResourceListProcessor:
 			p = cast
-		} else if cast, ok := input.(func(*ResourceList) (bool, error)); ok {
+		case func(*ResourceList) (bool, error):
 			p = ResourceListProcessorFunc(cast)
-		} else {
+		default:
 			return fmt.Errorf("unknown input type %T", input)
 		}
 

--- a/go/fn/run_test.go
+++ b/go/fn/run_test.go
@@ -64,7 +64,8 @@ func TestAsMainTypes(t *testing.T) {
 		"ResourceListProcessor":              &myRLP{},
 		"Implicit ResourceListProcessorFunc": myRLPF,
 		"Explicit ResourceListProcessorFunc": ResourceListProcessorFunc(myRLPF),
-		"runnerProcessor":                    runnerProcessor{ctx: t.Context(), fnRunner: &myFR{}},
+		"RunnerProcessor":                    runnerProcessor{ctx: t.Context(), fnRunner: &myFR{}},
+		"Anonymous":                          func(*ResourceList) (bool, error) { return true, nil },
 	}
 
 	for name, input := range testCases {

--- a/go/fn/run_test.go
+++ b/go/fn/run_test.go
@@ -16,6 +16,7 @@ package fn
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,4 +33,44 @@ func TestRunEmptyInputBytes(t *testing.T) {
 	require.NoError(t, err)
 	expected := fmt.Appendf(nil, "apiVersion: %s\nkind: %s\n", kio.ResourceListAPIVersion, kio.ResourceListKind)
 	assert.Equal(t, expected, output)
+}
+
+type myRLP struct{}
+
+func (*myRLP) Process(*ResourceList) (bool, error) {
+	return true, nil
+}
+
+func myRLPF(*ResourceList) (bool, error) {
+	return true, nil
+}
+
+type myFR struct{}
+
+func (*myFR) Run(*Context, *KubeObject, KubeObjects, *Results) bool {
+	return true
+}
+
+var _ ResourceListProcessor = &myRLP{}
+var _ ResourceListProcessorFunc = myRLPF
+var _ Runner = &myFR{}
+
+func TestAsMainTypes(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+	os.Args = []string{"cmd"}
+
+	testCases := map[string]any{
+		"ResourceListProcessor":              &myRLP{},
+		"Implicit ResourceListProcessorFunc": myRLPF,
+		"Explicit ResourceListProcessorFunc": ResourceListProcessorFunc(myRLPF),
+		"runnerProcessor":                    runnerProcessor{ctx: t.Context(), fnRunner: &myFR{}},
+	}
+
+	for name, input := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := AsMain(input)
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/go/fn/run_test.go
+++ b/go/fn/run_test.go
@@ -60,6 +60,15 @@ func TestAsMainTypes(t *testing.T) {
 	t.Cleanup(func() { os.Args = oldArgs })
 	os.Args = []string{"cmd"}
 
+	oldStdin := os.Stdin
+	devNull, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = devNull.Close()
+	})
+	os.Stdin = devNull
+
 	testCases := map[string]any{
 		"ResourceListProcessor":              &myRLP{},
 		"Implicit ResourceListProcessorFunc": myRLPF,


### PR DESCRIPTION
Currently, if you want to pass a function to AsMain, even if it has the correct ResourceListProcessorFunc signature, it will still fail the casting. Thus, it has to be explicitly wrapped.

With this PR, you can now just pass the function pointer or an anonymous/lambda function.

_No AI was used in the creation of this PR._