### PR TITLE
Remove version field from ResourceIdentifier

### DIFF
--- a/go/fn/origin.go
+++ b/go/fn/origin.go
@@ -37,7 +37,6 @@ const (
 
 type ResourceIdentifier struct {
 	Group     string
-	Version   string
 	Kind      string
 	Name      string
 	Namespace string


### PR DESCRIPTION
The version field of GVKNN is not used in the SDK for identity, and thus getID() doesn't set the version field of the returned ResourceIdentifier. 

This is correct behavior, however the presence of the version field is confusing for users, and the fact that GetID()  leaves it empty is unintuitive, so this PR removes this field.

Technically this is not a backward compatible change, but I guess that most cases where this will cause a compile error is actually reveals an actual error in the client code (because it expects the version field to be filled).