### PR TITLE
Add a function to clear the status on a kptfile

### DIFF
--- a/go/fn/kptfileko/kptfile.go
+++ b/go/fn/kptfileko/kptfile.go
@@ -20,6 +20,7 @@ import (
 
 	kptfileapi "github.com/kptdev/kpt/api/kptfile/v1"
 	"github.com/kptdev/krm-functions-sdk/go/fn"
+	pkgerrors "github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -95,6 +96,14 @@ func (kf *KptfileKubeObject) String() string {
 // If the Status field doesn't exist, it is added.
 func (kf *KptfileKubeObject) Status() *fn.SubObject {
 	return kf.UpsertMap("status")
+}
+
+// ClearStatus removes the status field from the KptfileKubeObject.
+func (kf *KptfileKubeObject) ClearStatus() error {
+	if _, err := kf.RemoveNestedField("status"); err != nil {
+		return pkgerrors.Wrap(err, "failed to remove status field from Kptfile")
+	}
+	return nil
 }
 
 // DecodeKptfile decodes a KptFile from a YAML string.

--- a/go/fn/kptfileko/kptfile_test.go
+++ b/go/fn/kptfileko/kptfile_test.go
@@ -297,7 +297,7 @@ status: {conditions: [{type: test, status: "True", message: Everything is awesom
 	}
 }
 
-func TestRemoveStatus(t *testing.T) {
+func TestClearStatus(t *testing.T) {
 	testcases := []struct {
 		name            string
 		resources       map[string]string

--- a/go/fn/kptfileko/kptfile_test.go
+++ b/go/fn/kptfileko/kptfile_test.go
@@ -296,3 +296,108 @@ status: {conditions: [{type: test, status: "True", message: Everything is awesom
 		})
 	}
 }
+
+func TestRemoveStatus(t *testing.T) {
+	testcases := []struct {
+		name            string
+		resources       map[string]string
+		expectedKptfile string
+	}{
+		{
+			name: "remove null status field",
+			resources: map[string]string{
+				"Kptfile": `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+status:`,
+			},
+			expectedKptfile: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example`,
+		},
+		{
+			name: "remove empty status field",
+			resources: map[string]string{
+				"Kptfile": `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+status: {}`,
+			},
+			expectedKptfile: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example`,
+		},
+		{
+			name: "remove bad status field",
+			resources: map[string]string{
+				"Kptfile": `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+status: bad`,
+			},
+			expectedKptfile: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example`,
+		},
+		{
+			name: "update existing half-empty condition",
+			resources: map[string]string{
+				"Kptfile": `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+status:
+  conditions:
+  - type: test`,
+			},
+			expectedKptfile: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example`,
+		},
+		{
+			name: "updating existing condition (one line)",
+			resources: map[string]string{
+				"Kptfile": `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+status: {conditions: [{type: test, status: "False", message: Everything is NOT awesome!, reason: TestFailed}]}`,
+			},
+			expectedKptfile: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			kptfile, err := NewFromPackage(tc.resources)
+			assert.NilError(t, err, "failed to parse Kptfile")
+
+			err = kptfile.ClearStatus()
+			assert.NilError(t, err, "failed to clear status")
+
+			err = kptfile.WriteToPackage(tc.resources)
+			assert.NilError(t, err, "failed to write conditions back to Kptfile")
+			assert.Equal(t, strings.TrimSpace(tc.expectedKptfile), strings.TrimSpace(tc.resources["Kptfile"]))
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a function to clear the status on a kptfile. When a package or subpackage is cloned or upgraded, it's status chould always be cleared. This function implements status clearing.

This PR partly addresses https://github.com/kptdev/porch/issues/1109